### PR TITLE
[codex] Unroll post-O3 scalar recurrences

### DIFF
--- a/docs/Pluto ABI Optimization Plan.md
+++ b/docs/Pluto ABI Optimization Plan.md
@@ -1,7 +1,7 @@
 # Pluto ABI Optimization Plan
 
-**Status:** Phase 1 scalar ABI shipped internally; remaining phases proposed
-**Scope:** Internal call lowering, scalar fast paths, tail recursion, external ABI stability
+**Status:** Phase 1 scalar ABI and post-O3 scalar recurrence unroll are implemented; remaining ABI phases proposed
+**Scope:** Internal call lowering, scalar fast paths, aggregate returns, external ABI stability, targeted post-LLVM loop cleanup
 
 ## 1. Problem
 
@@ -19,7 +19,9 @@ Simple and uniform, but costly for scalar-heavy code:
 - single-scalar outputs use `sret` instead of register return
 - self tail recursion lowers to recursive calls plus stack traffic instead of loops
 
-The `fib_tail` benchmark exposes this clearly. LLVM `-O3` cannot recover from ABI choices baked into the function signature — it can promote local allocas and simplify CFGs, but it cannot fix pointer-based param ABI or `sret`-only returns. ABI classification and tail-recursion lowering must be done in Pluto.
+The `fib_tail` benchmark originally exposed this clearly. LLVM `-O3` cannot recover from ABI choices baked into the function signature — it can promote local allocas and simplify CFGs, but it cannot fix pointer-based param ABI or `sret`-only returns. ABI classification must be done in Pluto.
+
+After Phase 1, `fib_tail` is no longer a strong argument for a Pluto-level tail-call optimization pass: with direct scalar params and returns, LLVM can already eliminate the simple self recursion and inline the helper into the benchmark loop. A Pluto TCO pass should be considered only for stack-safety or broader semantic reasons, not as the next performance optimization.
 
 ## 2. Key Principle: Separate Semantics from ABI
 
@@ -81,25 +83,24 @@ This was the highest-value initial optimization because it benefits all scalar-h
 
 **Benchmark target:** `fib`, `fib_tail`, and other call-heavy scalar code. Note: `sum` is not a useful target here — its optimized IR is already a call-free scalar loop; the current gap vs clang is loop optimization quality, not call ABI.
 
-### Phase 2: Restricted self tail recursion (next highest priority)
+### Phase 2: Restricted self tail recursion (deprioritized)
 
 Transform self-recursive calls into loops when all of:
 
 - direct scalar params only
 - single direct scalar return
 - self call in tail position
-- no ownership-sensitive temporaries live across the tail call
-- no cleanup work required before return
+- cleanup for any owned locals can be emitted explicitly on the tail backedge
 
-Intentionally narrow — ignore multi-output, strings, arrays, mutual recursion. This is medium difficulty because the restricted form avoids all the hard ownership/cleanup interactions.
+This is not currently worth pursuing as a performance phase. An experiment against `fib_tail` showed that optimized baseline IR already contains no recursive `FibAux` call after Phase 1, and standalone binary timings were within noise of a custom Pluto loop lowering. The compiler complexity is therefore not justified for this benchmark.
 
-**Benchmark target:** `fib_tail` (eliminates stack growth entirely and removes the remaining recursive-call overhead after Phase 1).
+Keep this as a future stack-safety/language-semantics feature only. If revisited, the implementation should be a real analysis/lowering pass with explicit backedge cleanup, not a benchmark-specific special case.
 
 ### Phase 3: Small POD aggregate returns
 
 Support direct multi-output returns for plain-data aggregates (`{I64, I64}`, `{I64, F64}`) when the target ABI allows. Model as LLVM aggregate return and let target classification decide direct vs indirect.
 
-This is the natural next ABI expansion after Phase 2 because the classifier/lowering split from Phase 1 is already in place. The remaining work is target-aware aggregate classification, not another structural refactor.
+This is the natural next ABI expansion because the classifier/lowering split from Phase 1 is already in place. The remaining work is target-aware aggregate classification, not another structural refactor.
 
 ### Phase 4: Generalized ABI classification
 
@@ -116,8 +117,28 @@ for that benchmark is already a call-free scalar loop, but clang still produces 
 more optimized kernel. That means `sum` should be treated as a loop/codegen quality
 benchmark, not as a primary validation target for the ABI phases above.
 
-The target-metadata quick wins have already landed far enough to make this a
-different problem now. The next things to investigate here are:
+The first targeted loop/codegen step is implemented: after LLVM `default<O3>`,
+Pluto annotates small scalar recurrence loops with `llvm.loop.unroll.count = 4`
+and reruns only LLVM's function loop unroller. This is deliberately post-O3 so
+it can see loops created by LLVM inlining and tail-recursion elimination. It is
+not a global `--unroll-count=4` policy.
+
+This pass targets the post-inline `fib_tail` recurrence and intentionally leaves
+broader loop classes to LLVM's normal cost model:
+
+- `fib_tail` benefits because the helper has become a small scalar recurrence loop
+- `sum` is rejected because the hot loop contains integer remainder (`% 17`)
+- `harmonic` is currently vectorized by LLVM on the benchmarked target, so its
+  post-O3 IR has vector operations and existing loop metadata; a scalar `fdiv`
+  recurrence remains eligible if LLVM does not vectorize it
+
+Regression coverage compiles a real Pluto `fib_tail` fixture, runs the same
+post-O3 pipeline in-process, and checks that metadata reaches the post-inline
+recurrence before LLVM's loop unroller runs. Broader A/B experiments should use
+temporary local compiler builds rather than permanent user-facing optimization
+knobs.
+
+The next things to investigate for loop/codegen quality are:
 
 - emit a more canonical counted-loop fast path for common `I64` ranges, especially `step == 1`
 - preserve affine-friendly loop structure so LLVM can unroll and strength-reduce more aggressively
@@ -128,7 +149,9 @@ These are worth treating as a separate optimization track because they improve
 call-free kernels like `sum` and still benefit range-heavy scalar code such as
 `harmonic`, without depending on more ABI surface area.
 
-**Benchmark target:** `sum`, `harmonic`, and other call-free or loop-dominated integer kernels.
+**Benchmark target:** `fib_tail` for the scalar recurrence unroll pass; `sum`,
+`harmonic`, and other call-free or loop-dominated kernels for future loop
+canonicalization and strength-reduction work.
 
 ## 5. Rollout Strategy
 
@@ -141,8 +164,17 @@ Each phase should:
 
 ## 6. Practical Recommendation
 
-If only one remaining optimization can be prioritized: **Phase 2** (restricted self tail recursion). Phase 1 is already shipped, and tail recursion is now the clearest remaining win on the benchmark set.
+If only one remaining optimization can be prioritized: **make the implemented
+post-O3 scalar recurrence unroll pass boring and well-covered**. It has a clear
+`fib_tail` win, a bounded eligibility filter, and a real post-opt IR regression
+test. Do not expand it toward `sum`/`harmonic` without a separate measured
+hypothesis.
 
-If two: **Phase 2 + Phase 3** (restricted tail recursion + small POD aggregate returns). That extends the current ABI work with the best continuity and risk/reward ratio.
+After that, prioritize **the counted-loop fast path from the non-ABI loop/codegen
+track**. Phase 1 is already shipped, and `fib_tail` no longer demonstrates a
+meaningful Pluto-level TCO win because LLVM already optimizes the simple tail
+recursion once scalar ABI lowering is in place.
 
-If a parallel non-ABI effort is desired at the same time, prioritize the counted-loop fast path from the loop/codegen track rather than additional cache or tooling work.
+If staying on ABI work, prioritize **Phase 3** (small POD aggregate returns) over custom TCO. That extends the current ABI work with clearer risk/reward and avoids adding a pass that current benchmarks do not justify.
+
+If a parallel non-ABI effort is desired at the same time, continue with the counted-loop fast path from the loop/codegen track rather than additional cache or tooling work.

--- a/llvm_pipeline.go
+++ b/llvm_pipeline.go
@@ -12,6 +12,17 @@ import (
 )
 
 const llvmOptPipeline = "default<O3>"
+const llvmScalarUnrollPipeline = "function(loop-unroll<O3>)"
+const llvmScalarUnrollCount = 4
+
+// Keep the forced unroll hint focused on small scalar recurrences. These limits
+// fit the post-inline fib_tail recurrence with headroom; broader loops stay
+// under LLVM's normal O3 cost model.
+const (
+	scalarUnrollMaxBlocks       = 5
+	scalarUnrollMaxInstructions = 32
+	scalarUnrollMaxMemoryOps    = 4
+)
 
 var (
 	llvmCodegenInitOnce sync.Once
@@ -101,6 +112,11 @@ func (p *Pluto) emitObject(module llvm.Module, objFile string) error {
 	if err := module.RunPasses(llvmOptPipeline, tm, pbo); err != nil {
 		return fmt.Errorf("optimize LLVM module with %s: %w", llvmOptPipeline, err)
 	}
+	if annotateScalarUnrollLoops(module) > 0 {
+		if err := module.RunPasses(llvmScalarUnrollPipeline, tm, pbo); err != nil {
+			return fmt.Errorf("optimize LLVM module with %s: %w", llvmScalarUnrollPipeline, err)
+		}
+	}
 
 	obj, err := tm.EmitToMemoryBuffer(module, llvm.ObjectFile)
 	if err != nil {
@@ -115,4 +131,329 @@ func (p *Pluto) emitObject(module llvm.Module, objFile string) error {
 		return fmt.Errorf("write object file %s: %w", objFile, err)
 	}
 	return nil
+}
+
+type scalarUnrollLoop struct {
+	header llvm.BasicBlock
+	latch  llvm.BasicBlock
+	term   llvm.Value
+	blocks map[llvm.BasicBlock]struct{}
+}
+
+func annotateScalarUnrollLoops(module llvm.Module) int {
+	ctx := module.Context()
+	loopMDKind := ctx.MDKindID("llvm.loop")
+	annotated := 0
+
+	for fn := module.FirstFunction(); !fn.IsNil(); fn = llvm.NextFunction(fn) {
+		loops := scalarUnrollCandidates(fn)
+		for _, loop := range loops {
+			if !loop.term.Metadata(loopMDKind).IsNil() {
+				continue
+			}
+			loop.term.SetMetadata(loopMDKind, llvmUnrollCountMetadata(ctx, llvmScalarUnrollCount))
+			annotated++
+		}
+	}
+
+	return annotated
+}
+
+func scalarUnrollCandidates(fn llvm.Value) []scalarUnrollLoop {
+	if fn.BasicBlocksCount() == 0 {
+		return nil
+	}
+	blocks := fn.BasicBlocks()
+	if len(blocks) == 0 {
+		return nil
+	}
+
+	preds := make(map[llvm.BasicBlock][]llvm.BasicBlock, len(blocks))
+	succs := make(map[llvm.BasicBlock][]llvm.BasicBlock, len(blocks))
+	for _, bb := range blocks {
+		term := bb.LastInstruction()
+		for _, succ := range branchSuccessors(term) {
+			succs[bb] = append(succs[bb], succ)
+			preds[succ] = append(preds[succ], bb)
+		}
+	}
+	entry := fn.EntryBasicBlock()
+	if entry.IsNil() {
+		return nil
+	}
+	doms := computeDominators(blocks, preds, entry)
+
+	var loops []scalarUnrollLoop
+	for _, latch := range blocks {
+		term := latch.LastInstruction()
+		if term.IsNil() || term.InstructionOpcode() != llvm.Br {
+			continue
+		}
+		for _, header := range succs[latch] {
+			if !dominates(doms, header, latch) {
+				continue
+			}
+			loopBlocks := collectNaturalLoop(header, latch, preds)
+			loop := scalarUnrollLoop{
+				header: header,
+				latch:  latch,
+				term:   term,
+				blocks: loopBlocks,
+			}
+			if loopIsWorthScalarUnroll(loop, preds, succs, doms) {
+				loops = append(loops, loop)
+			}
+		}
+	}
+
+	return loops
+}
+
+func branchSuccessors(term llvm.Value) []llvm.BasicBlock {
+	if term.IsNil() || term.InstructionOpcode() != llvm.Br {
+		return nil
+	}
+
+	succs := make([]llvm.BasicBlock, 0, 2)
+	for i := 0; i < term.OperandsCount(); i++ {
+		op := term.Operand(i)
+		if op.IsNil() || !op.IsBasicBlock() {
+			continue
+		}
+		succ := op.AsBasicBlock()
+		if !succ.IsNil() {
+			succs = append(succs, succ)
+		}
+	}
+	return succs
+}
+
+func computeDominators(blocks []llvm.BasicBlock, preds map[llvm.BasicBlock][]llvm.BasicBlock, entry llvm.BasicBlock) map[llvm.BasicBlock]map[llvm.BasicBlock]struct{} {
+	doms := make(map[llvm.BasicBlock]map[llvm.BasicBlock]struct{}, len(blocks))
+	if len(blocks) == 0 {
+		return doms
+	}
+
+	allBlocks := blockSet(blocks...)
+	for _, bb := range blocks {
+		if bb == entry {
+			doms[bb] = blockSet(bb)
+			continue
+		}
+		doms[bb] = cloneBlockSet(allBlocks)
+	}
+
+	changed := true
+	for changed {
+		changed = false
+		for _, bb := range blocks {
+			if bb == entry {
+				continue
+			}
+			predDoms := make([]map[llvm.BasicBlock]struct{}, 0, len(preds[bb]))
+			for _, pred := range preds[bb] {
+				if predDom, ok := doms[pred]; ok {
+					predDoms = append(predDoms, predDom)
+				}
+			}
+
+			next := intersectBlockSets(predDoms)
+			next[bb] = struct{}{}
+			if !sameBlockSet(doms[bb], next) {
+				doms[bb] = next
+				changed = true
+			}
+		}
+	}
+
+	return doms
+}
+
+func dominates(doms map[llvm.BasicBlock]map[llvm.BasicBlock]struct{}, dominator, bb llvm.BasicBlock) bool {
+	bbDoms, ok := doms[bb]
+	if !ok {
+		return false
+	}
+	_, ok = bbDoms[dominator]
+	return ok
+}
+
+func blockSet(blocks ...llvm.BasicBlock) map[llvm.BasicBlock]struct{} {
+	set := make(map[llvm.BasicBlock]struct{}, len(blocks))
+	for _, bb := range blocks {
+		set[bb] = struct{}{}
+	}
+	return set
+}
+
+func cloneBlockSet(set map[llvm.BasicBlock]struct{}) map[llvm.BasicBlock]struct{} {
+	clone := make(map[llvm.BasicBlock]struct{}, len(set))
+	for bb := range set {
+		clone[bb] = struct{}{}
+	}
+	return clone
+}
+
+func intersectBlockSets(sets []map[llvm.BasicBlock]struct{}) map[llvm.BasicBlock]struct{} {
+	if len(sets) == 0 {
+		return map[llvm.BasicBlock]struct{}{}
+	}
+
+	intersection := cloneBlockSet(sets[0])
+	for _, set := range sets[1:] {
+		for bb := range intersection {
+			if _, ok := set[bb]; !ok {
+				delete(intersection, bb)
+			}
+		}
+	}
+	return intersection
+}
+
+func sameBlockSet(a, b map[llvm.BasicBlock]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for bb := range a {
+		if _, ok := b[bb]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func collectNaturalLoop(header, latch llvm.BasicBlock, preds map[llvm.BasicBlock][]llvm.BasicBlock) map[llvm.BasicBlock]struct{} {
+	loopBlocks := map[llvm.BasicBlock]struct{}{
+		header: {},
+		latch:  {},
+	}
+	worklist := []llvm.BasicBlock{latch}
+
+	for len(worklist) > 0 {
+		bb := worklist[len(worklist)-1]
+		worklist = worklist[:len(worklist)-1]
+		if bb == header {
+			continue
+		}
+		for _, pred := range preds[bb] {
+			if _, ok := loopBlocks[pred]; ok {
+				continue
+			}
+			loopBlocks[pred] = struct{}{}
+			worklist = append(worklist, pred)
+		}
+	}
+
+	return loopBlocks
+}
+
+func loopIsWorthScalarUnroll(loop scalarUnrollLoop, preds, succs map[llvm.BasicBlock][]llvm.BasicBlock, doms map[llvm.BasicBlock]map[llvm.BasicBlock]struct{}) bool {
+	if len(loop.blocks) == 0 || len(loop.blocks) > scalarUnrollMaxBlocks {
+		return false
+	}
+
+	stats := scalarLoopStats{}
+	for bb := range loop.blocks {
+		for inst := bb.FirstInstruction(); !inst.IsNil(); inst = llvm.NextInstruction(inst) {
+			stats.observe(inst)
+			if stats.instructions > scalarUnrollMaxInstructions ||
+				stats.memoryOps > scalarUnrollMaxMemoryOps ||
+				stats.calls > 0 ||
+				stats.expensiveOps > 0 ||
+				stats.vectorOps > 0 ||
+				stats.unsupported > 0 {
+				return false
+			}
+		}
+		for _, succ := range succs[bb] {
+			if _, inLoop := loop.blocks[succ]; inLoop {
+				// In a single-block loop the latch-to-header backedge is a
+				// self-edge; dominance alone cannot distinguish it from an
+				// extra in-loop backedge.
+				if dominates(doms, succ, bb) && !(bb == loop.latch && succ == loop.header) {
+					return false
+				}
+				continue
+			}
+			stats.exits++
+		}
+		for _, pred := range preds[bb] {
+			if _, inLoop := loop.blocks[pred]; !inLoop && bb != loop.header {
+				return false
+			}
+		}
+	}
+
+	return stats.phis > 0 && stats.exits > 0 && stats.exits <= 2
+}
+
+type scalarLoopStats struct {
+	instructions int
+	phis         int
+	calls        int
+	memoryOps    int
+	expensiveOps int
+	vectorOps    int
+	unsupported  int
+	exits        int
+}
+
+func (s *scalarLoopStats) observe(inst llvm.Value) {
+	s.instructions++
+	if valueUsesVectorType(inst) {
+		s.vectorOps++
+	}
+
+	switch inst.InstructionOpcode() {
+	case llvm.PHI:
+		s.phis++
+	case llvm.Call:
+		if !isAllowedScalarUnrollCall(inst) {
+			s.calls++
+		}
+	case llvm.Load, llvm.Store, llvm.GetElementPtr:
+		s.memoryOps++
+	case llvm.UDiv, llvm.SDiv, llvm.URem, llvm.SRem, llvm.FRem:
+		s.expensiveOps++
+	case llvm.Invoke, llvm.IndirectBr, llvm.Switch, llvm.Ret, llvm.Resume, llvm.LandingPad,
+		llvm.CleanupRet, llvm.CatchRet, llvm.CatchPad, llvm.CleanupPad, llvm.CatchSwitch,
+		llvm.VAArg, llvm.ExtractElement, llvm.InsertElement, llvm.ShuffleVector:
+		s.unsupported++
+	}
+}
+
+func isAllowedScalarUnrollCall(inst llvm.Value) bool {
+	called := inst.CalledValue()
+	if called.IsNil() {
+		return false
+	}
+	name := called.Name()
+	// Keep this whitelist narrow until Pluto emits more side-effect-free
+	// intrinsics in scalar loops.
+	return strings.HasPrefix(name, "llvm.assume") || strings.HasPrefix(name, "llvm.lifetime.")
+}
+
+func valueUsesVectorType(v llvm.Value) bool {
+	if !v.Type().IsNil() && v.Type().TypeKind() == llvm.VectorTypeKind {
+		return true
+	}
+	for i := 0; i < v.OperandsCount(); i++ {
+		op := v.Operand(i)
+		if !op.IsNil() && !op.Type().IsNil() && op.Type().TypeKind() == llvm.VectorTypeKind {
+			return true
+		}
+	}
+	return false
+}
+
+func llvmUnrollCountMetadata(ctx llvm.Context, count int) llvm.Metadata {
+	temp := ctx.TemporaryMDNode(nil)
+	countMD := llvm.ConstInt(ctx.Int32Type(), uint64(count), false).ConstantAsMetadata()
+	countNode := ctx.MDNode([]llvm.Metadata{
+		ctx.MDString("llvm.loop.unroll.count"),
+		countMD,
+	})
+	loopID := ctx.MDNode([]llvm.Metadata{temp, countNode})
+	temp.ReplaceAllUsesWith(loopID)
+	return loopID
 }

--- a/llvm_pipeline_test.go
+++ b/llvm_pipeline_test.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thiremani/pluto/compiler"
+	"tinygo.org/x/go-llvm"
+)
+
+func parseTestIR(t *testing.T, ir string) llvm.Module {
+	t.Helper()
+
+	ctx := llvm.NewContext()
+	t.Cleanup(ctx.Dispose)
+
+	path := filepath.Join(t.TempDir(), "test.ll")
+	if err := os.WriteFile(path, []byte(ir), 0644); err != nil {
+		t.Fatalf("write test IR: %v", err)
+	}
+	buf, err := llvm.NewMemoryBufferFromFile(path)
+	if err != nil {
+		t.Fatalf("read test IR: %v", err)
+	}
+
+	mod, err := ctx.ParseIR(buf)
+	if err != nil {
+		t.Fatalf("parse test IR: %v", err)
+	}
+	t.Cleanup(mod.Dispose)
+	return mod
+}
+
+func TestAnnotateScalarUnrollLoopsMarksSmallScalarRecurrence(t *testing.T) {
+	mod := parseTestIR(t, `
+define i64 @fib_like(i64 %n) {
+entry:
+  br label %loop
+
+loop:
+  %a = phi i64 [ 0, %entry ], [ %b, %loop ]
+  %b = phi i64 [ 1, %entry ], [ %sum, %loop ]
+  %i = phi i64 [ %n, %entry ], [ %dec, %loop ]
+  %dec = add i64 %i, -1
+  %sum = add i64 %a, %b
+  %done = icmp eq i64 %dec, 0
+  br i1 %done, label %exit, label %loop
+
+exit:
+  ret i64 %b
+}
+`)
+
+	if got := annotateScalarUnrollLoops(mod); got != 1 {
+		t.Fatalf("annotateScalarUnrollLoops() = %d, want 1", got)
+	}
+	ir := mod.String()
+	if !strings.Contains(ir, "llvm.loop.unroll.count") {
+		t.Fatalf("expected unroll metadata in IR:\n%s", ir)
+	}
+}
+
+func TestAnnotateScalarUnrollLoopsSkipsCallHeavyLoops(t *testing.T) {
+	mod := parseTestIR(t, `
+declare void @side_effect()
+
+define void @call_loop(i64 %n) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i64 [ %n, %entry ], [ %dec, %loop ]
+  call void @side_effect()
+  %dec = add i64 %i, -1
+  %done = icmp eq i64 %dec, 0
+  br i1 %done, label %exit, label %loop
+
+exit:
+  ret void
+}
+`)
+
+	if got := annotateScalarUnrollLoops(mod); got != 0 {
+		t.Fatalf("annotateScalarUnrollLoops() = %d, want 0", got)
+	}
+}
+
+func TestAnnotateScalarUnrollLoopsSkipsExpensiveArithmetic(t *testing.T) {
+	mod := parseTestIR(t, `
+define i64 @rem_loop(i64 %n) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i64 [ %n, %entry ], [ %dec, %loop ]
+  %acc = phi i64 [ 0, %entry ], [ %next, %loop ]
+  %rem = srem i64 %i, 17
+  %next = add i64 %acc, %rem
+  %dec = add i64 %i, -1
+  %done = icmp eq i64 %dec, 0
+  br i1 %done, label %exit, label %loop
+
+exit:
+  ret i64 %next
+}
+`)
+
+	if got := annotateScalarUnrollLoops(mod); got != 0 {
+		t.Fatalf("annotateScalarUnrollLoops() = %d, want 0", got)
+	}
+}
+
+func TestAnnotateScalarUnrollLoopsAllowsFloatingDivision(t *testing.T) {
+	mod := parseTestIR(t, `
+define double @harmonic_like(i64 %n) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i64 [ %n, %entry ], [ %dec, %loop ]
+  %acc = phi double [ 0.0, %entry ], [ %next, %loop ]
+  %as_float = sitofp i64 %i to double
+  %term = fdiv double 1.0, %as_float
+  %next = fadd double %acc, %term
+  %dec = add i64 %i, -1
+  %done = icmp eq i64 %dec, 0
+  br i1 %done, label %exit, label %loop
+
+exit:
+  ret double %next
+}
+`)
+
+	if got := annotateScalarUnrollLoops(mod); got != 1 {
+		t.Fatalf("annotateScalarUnrollLoops() = %d, want 1", got)
+	}
+}
+
+func TestAnnotateScalarUnrollLoopsSkipsVectorLoops(t *testing.T) {
+	mod := parseTestIR(t, `
+define void @vector_loop(i64 %n, <2 x i64> %v) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i64 [ %n, %entry ], [ %dec, %loop ]
+  %acc = phi <2 x i64> [ %v, %entry ], [ %next, %loop ]
+  %next = add <2 x i64> %acc, %v
+  %dec = add i64 %i, -1
+  %done = icmp eq i64 %dec, 0
+  br i1 %done, label %exit, label %loop
+
+exit:
+  ret void
+}
+`)
+
+	if got := annotateScalarUnrollLoops(mod); got != 0 {
+		t.Fatalf("annotateScalarUnrollLoops() = %d, want 0", got)
+	}
+}
+
+func TestAnnotateScalarUnrollLoopsUsesDominatorsForBackedges(t *testing.T) {
+	mod := parseTestIR(t, `
+define i64 @reordered_loop(i64 %n) {
+entry:
+  br label %loop
+
+latch:
+  %done = icmp eq i64 %dec, 0
+  br i1 %done, label %exit, label %loop
+
+loop:
+  %i = phi i64 [ %n, %entry ], [ %dec, %latch ]
+  %acc = phi i64 [ 0, %entry ], [ %next, %latch ]
+  %next = add i64 %acc, %i
+  %dec = add i64 %i, -1
+  br label %latch
+
+exit:
+  ret i64 %next
+}
+`)
+
+	if got := annotateScalarUnrollLoops(mod); got != 1 {
+		t.Fatalf("annotateScalarUnrollLoops() = %d, want 1", got)
+	}
+}
+
+func TestScalarUnrollPipelineUnrollsPostInlineRecurrence(t *testing.T) {
+	mod := parseTestIR(t, `
+define i64 @post_inline_recurrence(i64 %outer_n) {
+entry:
+  br label %outer
+
+outer:
+  %iter = phi i64 [ 0, %entry ], [ %iter_next, %inner_exit ]
+  %sum = phi i64 [ 0, %entry ], [ %sum_next, %inner_exit ]
+  %inner_n = or i64 %iter, 32
+  br label %inner
+
+inner:
+  %b = phi i64 [ %fib_next, %inner ], [ 1, %outer ]
+  %a = phi i64 [ %b, %inner ], [ 0, %outer ]
+  %n = phi i64 [ %dec, %inner ], [ %inner_n, %outer ]
+  %dec = add i64 %n, -1
+  %fib_next = add i64 %a, %b
+  %inner_done = icmp eq i64 %dec, 0
+  br i1 %inner_done, label %inner_exit, label %inner
+
+inner_exit:
+  %sum_next = add i64 %sum, %b
+  %iter_next = add i64 %iter, 1
+  %outer_done = icmp eq i64 %iter_next, %outer_n
+  br i1 %outer_done, label %exit, label %outer
+
+exit:
+  ret i64 %sum_next
+}
+`)
+
+	if got := annotateScalarUnrollLoops(mod); got != 1 {
+		t.Fatalf("annotateScalarUnrollLoops() = %d, want 1", got)
+	}
+
+	tm, err := currentBuildConfig().newTargetMachine()
+	if err != nil {
+		t.Fatalf("new target machine: %v", err)
+	}
+	defer tm.Dispose()
+
+	pbo := llvm.NewPassBuilderOptions()
+	defer pbo.Dispose()
+	pbo.SetLoopUnrolling(true)
+	if err := mod.RunPasses(llvmScalarUnrollPipeline, tm, pbo); err != nil {
+		t.Fatalf("run scalar unroll pipeline: %v", err)
+	}
+
+	ir := mod.String()
+	if !strings.Contains(ir, "fib_next.3") {
+		t.Fatalf("expected inner recurrence to be unrolled:\n%s", ir)
+	}
+}
+
+func TestScalarUnrollAnnotatesRealPlutoFibTailLoop(t *testing.T) {
+	projectDir := t.TempDir()
+	t.Setenv("PTCACHE", filepath.Join(t.TempDir(), "cache"))
+
+	files := map[string]string{
+		MOD_FILE: "module github.com/thiremani/pluto/scalar_unroll_test\n",
+		"support.pt": `
+y = Fib(n)
+    y = FibAux(n, 0, 1)
+
+y = FibAux(n, a, b)
+    y = n == 0 a
+    y = n != 0 FibAux(n - 1, b, a + b)
+`,
+		"main.spt": `
+i = 0:1000000
+res = 0
+res = res + Fib(32 + i % 2)
+res
+`,
+	}
+	for name, contents := range files {
+		if err := os.WriteFile(filepath.Join(projectDir, name), []byte(contents), 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	p := New(projectDir, cliOptions{})
+	defer p.Ctx.Dispose()
+
+	codeFiles, scriptFiles := p.ScanPlutoFiles("")
+	if len(scriptFiles) != 1 {
+		t.Fatalf("scriptFiles = %v, want one script", scriptFiles)
+	}
+	cc, codeLL, err := p.CompileCode(codeFiles)
+	if err != nil {
+		t.Fatalf("compile code: %v", err)
+	}
+	scriptModule, err := p.CompileScript(scriptFiles[0], "main", cc, codeLL, map[string]*compiler.Func{}, map[compiler.ExprKey]*compiler.ExprInfo{})
+	if err != nil {
+		t.Fatalf("compile script: %v", err)
+	}
+	defer scriptModule.Dispose()
+
+	tm, err := currentBuildConfig().newTargetMachine()
+	if err != nil {
+		t.Fatalf("new target machine: %v", err)
+	}
+	defer tm.Dispose()
+
+	pbo := llvm.NewPassBuilderOptions()
+	defer pbo.Dispose()
+	pbo.SetLoopInterleaving(true)
+	pbo.SetLoopVectorization(true)
+	pbo.SetSLPVectorization(true)
+	pbo.SetLoopUnrolling(true)
+	if err := scriptModule.RunPasses(llvmOptPipeline, tm, pbo); err != nil {
+		t.Fatalf("run O3 pipeline: %v", err)
+	}
+	if got := annotateScalarUnrollLoops(scriptModule); got == 0 {
+		t.Fatalf("expected scalar unroll metadata on real Pluto post-O3 IR:\n%s", scriptModule.String())
+	}
+	if !strings.Contains(scriptModule.String(), "llvm.loop.unroll.count") {
+		t.Fatalf("expected scalar unroll metadata in real Pluto post-O3 IR:\n%s", scriptModule.String())
+	}
+
+	if err := scriptModule.RunPasses(llvmScalarUnrollPipeline, tm, pbo); err != nil {
+		t.Fatalf("run scalar unroll pipeline: %v", err)
+	}
+	postUnrollIR := scriptModule.String()
+	if !strings.Contains(postUnrollIR, "add_tmp.i.i.3") || !strings.Contains(postUnrollIR, "llvm.loop.unroll.disable") {
+		t.Fatalf("expected unrolled recurrence in real Pluto post-unroll IR:\n%s", postUnrollIR)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a targeted post-LLVM optimization step for small scalar recurrence loops. After the existing `default<O3>` pipeline runs, Pluto now identifies conservative scalar loop candidates, attaches `llvm.loop.unroll.count = 4`, and reruns only LLVM's function loop unroller. This catches the post-inline `fib_tail` recurrence after LLVM has already inlined and eliminated the source tail recursion.

The eligibility filter intentionally avoids vectorized loops, existing loop metadata, calls, integer div/rem, and larger loop bodies so the pass does not overwrite LLVM's normal O3 cost model for loops like `sum` and for the currently-vectorized `harmonic` benchmark shape. This intentionally does not add a permanent env-var kill switch; broader A/B or debug toggles should use temporary local compiler builds rather than growing user-facing optimizer knobs.

## Details

- Adds post-O3 scalar loop candidate detection with local dominator-based backedge handling.
- Builds self-referential LLVM loop metadata for `llvm.loop.unroll.count`.
- Adds synthetic IR tests for accepted/rejected loop shapes, reordered block layout, vector loops, calls, and expensive arithmetic.
- Adds a real Pluto `fib_tail`-style fixture test that runs O3 in-process, verifies annotation reaches the post-inline recurrence, and verifies LLVM unrolls it.
- Updates the ABI optimization plan to reflect that Pluto-level TCO is deprioritized for this benchmark and that this pass is a targeted loop/codegen track item.

## Validation

- `go test ./...`
- `python3 test.py` (`59 Passed`)
- Bench repo `fib_tail` showed the expected speedup in local runs; broader forced unroll experiments for `%`/`/` were intentionally not shipped because they regressed the real `sum` benchmark and did not materially improve `harmonic`.
