### PR TITLE
[codex] add logical OR support

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -445,10 +445,15 @@ type InfixExpression struct {
 	Right    Expression
 }
 
+// IsLogicalOr reports whether ie is a logical OR infix expression.
+func (ie *InfixExpression) IsLogicalOr() bool {
+	return ie.Operator == token.SYM_LOGICAL_OR
+}
+
 // IsLogicalOr returns exp as an infix logical OR expression.
 func IsLogicalOr(exp Expression) (*InfixExpression, bool) {
 	infix, ok := exp.(*InfixExpression)
-	if !ok || infix.Operator != token.SYM_LOGICAL_OR {
+	if !ok || !infix.IsLogicalOr() {
 		return nil, false
 	}
 	return infix, true

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -445,6 +445,15 @@ type InfixExpression struct {
 	Right    Expression
 }
 
+// IsLogicalOr returns exp as an infix logical OR expression.
+func IsLogicalOr(exp Expression) (*InfixExpression, bool) {
+	infix, ok := exp.(*InfixExpression)
+	if !ok || infix.Operator != token.SYM_LOGICAL_OR {
+		return nil, false
+	}
+	return infix, true
+}
+
 func (ie *InfixExpression) expressionNode()  {}
 func (ie *InfixExpression) Tok() token.Token { return ie.Token }
 func (ie *InfixExpression) String() string {

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -447,7 +447,7 @@ type InfixExpression struct {
 
 // IsLogicalOr reports whether ie is a logical OR infix expression.
 func (ie *InfixExpression) IsLogicalOr() bool {
-	return ie.Operator == token.SYM_LOGICAL_OR
+	return ie.Operator == token.SYM_COND_OR
 }
 
 // IsLogicalOr returns exp as an infix logical OR expression.

--- a/compiler/array.go
+++ b/compiler/array.go
@@ -950,7 +950,7 @@ func (c *Compiler) compileArrayRangeRanges(info *ExprInfo, dest []*ast.Identifie
 	output := outputs[0]
 
 	withCollectorPreparedLoopNest(c, info.Rewrite.(*ast.ArrayRangeExpression), info.Ranges, nil, nil, func(rew *ast.ArrayRangeExpression) {
-		c.compileOperandCondExprValue(rew, llvm.Value{}, func() {
+		c.compileCondOperands(rew, llvm.Value{}, func() {
 			arraySym, idxSym, arrType := c.compileArrayRangeOperands(rew)
 			// Source operands are temporary for each loop iteration in this path.
 			defer c.freeTemporary(rew.Array, []*Symbol{arraySym})

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1618,6 +1618,10 @@ func (c *Compiler) compileInfixExpression(expr *ast.InfixExpression, dest []*ast
 // It handles pointer operands, array-scalar broadcasting, and delegates to
 // the default operator table for scalar work.
 func (c *Compiler) compileInfix(op string, left *Symbol, right *Symbol, expected Type) *Symbol {
+	if op == token.SYM_LOGICAL_OR {
+		panic("internal: logical OR must be lowered through short-circuit branching")
+	}
+
 	l := c.derefIfPointer(left, "")
 	r := c.derefIfPointer(right, "")
 
@@ -1705,6 +1709,10 @@ func (c *Compiler) compileCondScalar(op string, left *Symbol, right *Symbol) *Sy
 }
 
 func (c *Compiler) compileInfixBasic(expr *ast.InfixExpression, info *ExprInfo) (res []*Symbol) {
+	if expr.Operator == token.SYM_LOGICAL_OR && !info.HasCondOr() {
+		return c.compileLogicalOrCondition(expr)
+	}
+
 	// For infix operators, both operands are evaluated in non-root context
 	// since they should not independently create loops
 	left := c.compileExpression(expr.Left, nil)
@@ -1733,6 +1741,40 @@ func (c *Compiler) compileInfixBasic(expr *ast.InfixExpression, info *ExprInfo) 
 	c.freeTemporary(expr.Right, right)
 
 	return res
+}
+
+func (c *Compiler) compileLogicalOrCondition(expr *ast.InfixExpression) []*Symbol {
+	left := c.compileExpression(expr.Left, nil)
+	if len(left) != 1 {
+		panic(fmt.Sprintf("internal: logical OR left operand produced %d values", len(left)))
+	}
+	leftSym := c.derefIfPointer(left[0], "")
+
+	trueBlock, rhsBlock, contBlock := c.createIfElseCont(leftSym.Val, "or_true", "or_rhs", "or_cont")
+
+	c.builder.SetInsertPointAtEnd(trueBlock)
+	c.freeTemporary(expr.Left, left)
+	c.builder.CreateBr(contBlock)
+	trueEnd := c.builder.GetInsertBlock()
+
+	c.builder.SetInsertPointAtEnd(rhsBlock)
+	right := c.compileExpression(expr.Right, nil)
+	if len(right) != 1 {
+		panic(fmt.Sprintf("internal: logical OR right operand produced %d values", len(right)))
+	}
+	rightSym := c.derefIfPointer(right[0], "")
+	c.freeTemporary(expr.Right, right)
+	c.builder.CreateBr(contBlock)
+	rhsEnd := c.builder.GetInsertBlock()
+
+	c.builder.SetInsertPointAtEnd(contBlock)
+	result := c.builder.CreatePHI(c.Context.Int1Type(), "or_cond")
+	result.AddIncoming(
+		[]llvm.Value{llvm.ConstInt(c.Context.Int1Type(), 1, false), rightSym.Val},
+		[]llvm.BasicBlock{trueEnd, rhsEnd},
+	)
+
+	return []*Symbol{{Val: result, Type: I1}}
 }
 
 // freeTemporary frees operands that are temporaries (not variables).

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1720,6 +1720,8 @@ func (c *Compiler) compileInfixBasic(expr *ast.InfixExpression, info *ExprInfo) 
 			// Usually pre-extracted via condLHS, but can still occur when range
 			// comparisons are scalarized by an outer loop (e.g. call arg vectorization).
 			res = append(res, c.compileCondScalar(expr.Operator, left[i], right[i]))
+		case CondOr:
+			panic("internal: value-position logical OR must be lowered through conditional expression branching")
 		default:
 			res = append(res, c.compileInfix(expr.Operator, left[i], right[i], info.OutTypes[i]))
 		}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1618,10 +1618,6 @@ func (c *Compiler) compileInfixExpression(expr *ast.InfixExpression, dest []*ast
 // It handles pointer operands, array-scalar broadcasting, and delegates to
 // the default operator table for scalar work.
 func (c *Compiler) compileInfix(op string, left *Symbol, right *Symbol, expected Type) *Symbol {
-	if op == token.SYM_LOGICAL_OR {
-		panic("internal: logical OR must be lowered through short-circuit branching")
-	}
-
 	l := c.derefIfPointer(left, "")
 	r := c.derefIfPointer(right, "")
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1705,7 +1705,7 @@ func (c *Compiler) compileCondScalar(op string, left *Symbol, right *Symbol) *Sy
 }
 
 func (c *Compiler) compileInfixBasic(expr *ast.InfixExpression, info *ExprInfo) (res []*Symbol) {
-	if _, isLogicalOr := ast.IsLogicalOr(expr); isLogicalOr && !info.HasFallbackOr() {
+	if expr.IsLogicalOr() && !info.HasFallbackOr() {
 		return c.compileLogicalOrCondition(expr)
 	}
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1746,14 +1746,12 @@ func (c *Compiler) compileLogicalOrCondition(expr *ast.InfixExpression) []*Symbo
 	trueBlock, rhsBlock, contBlock := c.createIfElseCont(leftSym.Val, "or_true", "or_rhs", "or_cont")
 
 	c.builder.SetInsertPointAtEnd(trueBlock)
-	c.freeTemporary(expr.Left, left)
 	c.builder.CreateBr(contBlock)
 	trueEnd := c.builder.GetInsertBlock()
 
 	c.builder.SetInsertPointAtEnd(rhsBlock)
 	right := c.compileExpression(expr.Right, nil)
 	rightSym := c.derefIfPointer(right[0], "")
-	c.freeTemporary(expr.Right, right)
 	c.builder.CreateBr(contBlock)
 	rhsEnd := c.builder.GetInsertBlock()
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1705,7 +1705,7 @@ func (c *Compiler) compileCondScalar(op string, left *Symbol, right *Symbol) *Sy
 }
 
 func (c *Compiler) compileInfixBasic(expr *ast.InfixExpression, info *ExprInfo) (res []*Symbol) {
-	if expr.Operator == token.SYM_LOGICAL_OR && !info.HasCondOr() {
+	if expr.Operator == token.SYM_LOGICAL_OR && !info.HasFallbackOr() {
 		return c.compileLogicalOrCondition(expr)
 	}
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1705,7 +1705,7 @@ func (c *Compiler) compileCondScalar(op string, left *Symbol, right *Symbol) *Sy
 }
 
 func (c *Compiler) compileInfixBasic(expr *ast.InfixExpression, info *ExprInfo) (res []*Symbol) {
-	if expr.Operator == token.SYM_LOGICAL_OR && !info.HasFallbackOr() {
+	if _, isLogicalOr := ast.IsLogicalOr(expr); isLogicalOr && !info.HasFallbackOr() {
 		return c.compileLogicalOrCondition(expr)
 	}
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1741,9 +1741,6 @@ func (c *Compiler) compileInfixBasic(expr *ast.InfixExpression, info *ExprInfo) 
 
 func (c *Compiler) compileLogicalOrCondition(expr *ast.InfixExpression) []*Symbol {
 	left := c.compileExpression(expr.Left, nil)
-	if len(left) != 1 {
-		panic(fmt.Sprintf("internal: logical OR left operand produced %d values", len(left)))
-	}
 	leftSym := c.derefIfPointer(left[0], "")
 
 	trueBlock, rhsBlock, contBlock := c.createIfElseCont(leftSym.Val, "or_true", "or_rhs", "or_cont")
@@ -1755,9 +1752,6 @@ func (c *Compiler) compileLogicalOrCondition(expr *ast.InfixExpression) []*Symbo
 
 	c.builder.SetInsertPointAtEnd(rhsBlock)
 	right := c.compileExpression(expr.Right, nil)
-	if len(right) != 1 {
-		panic(fmt.Sprintf("internal: logical OR right operand produced %d values", len(right)))
-	}
 	rightSym := c.derefIfPointer(right[0], "")
 	c.freeTemporary(expr.Right, right)
 	c.builder.CreateBr(contBlock)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1849,7 +1849,7 @@ func (c *Compiler) compileInfixRanges(expr *ast.InfixExpression, info *ExprInfo,
 		c.pushBoundsGuard("infix_iter_bounds_guard")
 		defer c.popBoundsGuard()
 
-		c.compileOperandCondExprValue(prepared, llvm.Value{}, func() {
+		c.compileCondOperands(prepared, llvm.Value{}, func() {
 			left := c.compileExpression(leftRew, nil)
 			right := c.compileExpression(rightRew, nil)
 
@@ -2118,7 +2118,7 @@ func (c *Compiler) compilePrefixRanges(expr *ast.PrefixExpression, info *ExprInf
 		c.pushBoundsGuard("prefix_iter_bounds_guard")
 		defer c.popBoundsGuard()
 
-		c.compileOperandCondExprValue(prepared, llvm.Value{}, func() {
+		c.compileCondOperands(prepared, llvm.Value{}, func() {
 			ops := c.compileExpression(rightRew, nil)
 
 			for i := 0; i < len(ops); i++ {

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -630,14 +630,12 @@ func (c *Compiler) compileCondExprWithFailure(expr ast.Expression, baseCond llvm
 func (c *Compiler) withCondLHS(expr ast.Expression, syms []*Symbol, body func()) {
 	frame := c.requireCondLHSFrame()
 	exprKey := key(c.FuncNameMangled, expr)
-	old, hadOld := frame[exprKey]
-	frame[exprKey] = syms
-	body()
-	if hadOld {
-		frame[exprKey] = old
-		return
+	if _, exists := frame[exprKey]; exists {
+		panic("internal: condLHS binding already active for expression")
 	}
-	delete(frame, exprKey)
+	frame[exprKey] = syms
+	defer delete(frame, exprKey)
+	body()
 }
 
 func (c *Compiler) compileLogicalOrCondExprWithFailure(expr *ast.InfixExpression, baseCond llvm.Value, onTrue func(), onFalse func()) {

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -475,29 +475,30 @@ func (c *Compiler) extractCondExprs(expr ast.Expression, cond llvm.Value, temps 
 	// Comparisons with ranges can be extracted only when all required iterators
 	// are already bound by an outer loop (no pending ranges).
 	if infix, ok := expr.(*ast.InfixExpression); ok && info.HasCondScalar() && len(c.pendingLoopRanges(info.Ranges)) == 0 {
-		// Bottom-up: extract conditions from operands first
 		cond, temps = c.extractCondExprs(infix.Left, cond, temps)
 		cond, temps = c.extractCondExprs(infix.Right, cond, temps)
-
-		// Compile both operands (may return pre-extracted values)
-		left := c.compileExpression(infix.Left, nil)
-		right := c.compileExpression(infix.Right, nil)
-
-		var lhsSyms []*Symbol
-		lhsSyms, cond = c.handleComparisons(infix.Operator, left, right, info, cond)
-
-		c.requireCondLHSFrame()[key(c.FuncNameMangled, expr)] = lhsSyms
-		temps = append(temps, condTemp{infix.Left, left})
-		// Free right-side temporaries (only used for comparison).
-		// Left-side values are retained in condLHS for later substitution.
-		c.freeTemporary(infix.Right, right)
-		return cond, temps
+		return c.extractCondExprSelf(infix, info, cond, temps)
 	}
 
 	// Not a conditional expression — recurse into children
 	for _, child := range ast.ExprChildren(expr) {
 		cond, temps = c.extractCondExprs(child, cond, temps)
 	}
+	return cond, temps
+}
+
+func (c *Compiler) extractCondExprSelf(infix *ast.InfixExpression, info *ExprInfo, cond llvm.Value, temps []condTemp) (llvm.Value, []condTemp) {
+	left := c.compileExpression(infix.Left, nil)
+	right := c.compileExpression(infix.Right, nil)
+
+	var lhsSyms []*Symbol
+	lhsSyms, cond = c.handleComparisons(infix.Operator, left, right, info, cond)
+
+	c.requireCondLHSFrame()[key(c.FuncNameMangled, infix)] = lhsSyms
+	temps = append(temps, condTemp{infix.Left, left})
+	// Free right-side temporaries (only used for comparison).
+	// Left-side values are retained in condLHS for later substitution.
+	c.freeTemporary(infix.Right, right)
 	return cond, temps
 }
 
@@ -530,7 +531,7 @@ func (c *Compiler) compileCondExprValue(expr ast.Expression, baseCond llvm.Value
 
 func (c *Compiler) compileCondExprValueInFrame(expr ast.Expression, baseCond llvm.Value, onTrue func()) {
 	if c.hasLogicalOrCondExprInTree(expr) {
-		c.compileCondExprAlternative(expr, baseCond, onTrue, func() {})
+		c.compileCondExprWithFailure(expr, baseCond, onTrue, func() {})
 		return
 	}
 
@@ -591,7 +592,7 @@ func (c *Compiler) compileCondExprChildrenInFrame(children []ast.Expression, bas
 	child := children[0]
 	rest := children[1:]
 	if c.hasCondExprInTree(child) {
-		c.compileCondExprAlternative(child, baseCond, func() {
+		c.compileCondExprWithFailure(child, baseCond, func() {
 			c.compileCondExprChildrenInFrame(rest, llvm.Value{}, onTrue, onFalse)
 		}, onFalse)
 		return
@@ -600,9 +601,9 @@ func (c *Compiler) compileCondExprChildrenInFrame(children []ast.Expression, bas
 	c.compileCondExprChildrenInFrame(rest, baseCond, onTrue, onFalse)
 }
 
-func (c *Compiler) compileCondExprAlternative(expr ast.Expression, baseCond llvm.Value, onTrue func(), onFalse func()) {
+func (c *Compiler) compileCondExprWithFailure(expr ast.Expression, baseCond llvm.Value, onTrue func(), onFalse func()) {
 	if logicalOr, ok := c.logicalOrCondExpr(expr); ok {
-		c.compileLogicalOrCondExprAlternative(logicalOr, baseCond, onTrue, onFalse)
+		c.compileLogicalOrCondExprWithFailure(logicalOr, baseCond, onTrue, onFalse)
 		return
 	}
 
@@ -616,13 +617,7 @@ func (c *Compiler) compileCondExprAlternative(expr ast.Expression, baseCond llvm
 		if infix, ok := expr.(*ast.InfixExpression); ok {
 			info := c.ExprCache[key(c.FuncNameMangled, infix)]
 			if info != nil && info.HasCondScalar() && len(c.pendingLoopRanges(info.Ranges)) == 0 {
-				left := c.compileExpression(infix.Left, nil)
-				right := c.compileExpression(infix.Right, nil)
-
-				lhsSyms, cond := c.handleComparisons(infix.Operator, left, right, info, llvm.Value{})
-				c.requireCondLHSFrame()[key(c.FuncNameMangled, expr)] = lhsSyms
-				temps := []condTemp{{infix.Left, left}}
-				c.freeTemporary(infix.Right, right)
+				cond, temps := c.extractCondExprSelf(infix, info, llvm.Value{}, nil)
 				c.compileCondExprBranchWithFailure(cond, temps, onTrue, onFalse)
 				return
 			}
@@ -645,7 +640,14 @@ func (c *Compiler) withCondLHS(expr ast.Expression, syms []*Symbol, body func())
 	delete(frame, exprKey)
 }
 
-func (c *Compiler) compileLogicalOrCondExprAlternative(expr *ast.InfixExpression, baseCond llvm.Value, onTrue func(), onFalse func()) {
+func (c *Compiler) compileLogicalOrCondExprWithFailure(expr *ast.InfixExpression, baseCond llvm.Value, onTrue func(), onFalse func()) {
+	if !baseCond.IsNil() {
+		c.compileCondExprBranchWithFailure(baseCond, nil, func() {
+			c.compileLogicalOrCondExprWithFailure(expr, llvm.Value{}, onTrue, onFalse)
+		}, onFalse)
+		return
+	}
+
 	leftTrue := func() {
 		left := c.compileExpression(expr.Left, nil)
 		c.withCondLHS(expr, left, onTrue)
@@ -655,8 +657,8 @@ func (c *Compiler) compileLogicalOrCondExprAlternative(expr *ast.InfixExpression
 		c.withCondLHS(expr, right, onTrue)
 	}
 
-	c.compileCondExprAlternative(expr.Left, baseCond, leftTrue, func() {
-		c.compileCondExprAlternative(expr.Right, baseCond, rightTrue, onFalse)
+	c.compileCondExprWithFailure(expr.Left, llvm.Value{}, leftTrue, func() {
+		c.compileCondExprWithFailure(expr.Right, llvm.Value{}, rightTrue, onFalse)
 	})
 }
 

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/thiremani/pluto/ast"
+	"github.com/thiremani/pluto/token"
 	"tinygo.org/x/go-llvm"
 )
 
@@ -401,14 +402,36 @@ func (c *Compiler) valuesHaveCondExpr(values []ast.Expression) bool {
 }
 
 // hasCondExprInTree returns true if any node in the expression tree has
-// CondScalar set (a scalar comparison in value position).
+// conditional value lowering.
 func (c *Compiler) hasCondExprInTree(expr ast.Expression) bool {
 	info := c.ExprCache[key(c.FuncNameMangled, expr)]
-	if info != nil && info.HasCondScalar() {
+	if info != nil && info.HasCondExpr() {
 		return true
 	}
 	for _, child := range ast.ExprChildren(expr) {
 		if c.hasCondExprInTree(child) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Compiler) logicalOrCondExpr(expr ast.Expression) (*ast.InfixExpression, bool) {
+	infix, ok := expr.(*ast.InfixExpression)
+	if !ok || infix.Operator != token.SYM_LOGICAL_OR {
+		return nil, false
+	}
+
+	info := c.ExprCache[key(c.FuncNameMangled, expr)]
+	return infix, info != nil && info.HasCondOr()
+}
+
+func (c *Compiler) hasLogicalOrCondExprInTree(expr ast.Expression) bool {
+	if _, ok := c.logicalOrCondExpr(expr); ok {
+		return true
+	}
+	for _, child := range ast.ExprChildren(expr) {
+		if c.hasLogicalOrCondExprInTree(child) {
 			return true
 		}
 	}
@@ -494,12 +517,22 @@ func (c *Compiler) cleanupCondExprElse(temps []condTemp) {
 	}
 }
 
-// compileCondExprValue extracts cond-expr predicates for expr, branches on the
-// combined condition (AND with baseCond when provided), and compiles onTrue on
-// the true path only. False path performs standard cond-expr cleanup.
+// compileCondExprValue extracts cond-expr predicates for expr, branches through
+// value-position conditions, and compiles onTrue on admitted paths only. Plain
+// comparisons compose as AND; value-position logical OR tries the left operand
+// first and falls back to the right operand only on the left false path.
 func (c *Compiler) compileCondExprValue(expr ast.Expression, baseCond llvm.Value, onTrue func()) {
 	c.pushCondLHSFrame()
 	defer c.popCondLHSFrame()
+
+	c.compileCondExprValueInFrame(expr, baseCond, onTrue)
+}
+
+func (c *Compiler) compileCondExprValueInFrame(expr ast.Expression, baseCond llvm.Value, onTrue func()) {
+	if c.hasLogicalOrCondExprInTree(expr) {
+		c.compileCondExprAlternative(expr, baseCond, onTrue, func() {})
+		return
+	}
 
 	cond, temps := c.extractCondExprs(expr, baseCond, nil)
 	c.compileCondExprBranch(cond, temps, onTrue)
@@ -512,6 +545,11 @@ func (c *Compiler) compileOperandCondExprValue(expr ast.Expression, baseCond llv
 	c.pushCondLHSFrame()
 	defer c.popCondLHSFrame()
 
+	if c.hasLogicalOrCondExprInTree(expr) {
+		c.compileCondExprChildrenInFrame(ast.ExprChildren(expr), baseCond, onTrue, func() {})
+		return
+	}
+
 	cond := baseCond
 	var temps []condTemp
 	for _, child := range ast.ExprChildren(expr) {
@@ -521,6 +559,10 @@ func (c *Compiler) compileOperandCondExprValue(expr ast.Expression, baseCond llv
 }
 
 func (c *Compiler) compileCondExprBranch(cond llvm.Value, temps []condTemp, onTrue func()) {
+	c.compileCondExprBranchWithFailure(cond, temps, onTrue, func() {})
+}
+
+func (c *Compiler) compileCondExprBranchWithFailure(cond llvm.Value, temps []condTemp, onTrue func(), onFalse func()) {
 	if cond.IsNil() {
 		onTrue()
 		return
@@ -534,9 +576,88 @@ func (c *Compiler) compileCondExprBranch(cond llvm.Value, temps []condTemp, onTr
 
 	c.builder.SetInsertPointAtEnd(elseBlock)
 	c.cleanupCondExprElse(temps)
+	onFalse()
 	c.builder.CreateBr(contBlock)
 
 	c.builder.SetInsertPointAtEnd(contBlock)
+}
+
+func (c *Compiler) compileCondExprChildrenInFrame(children []ast.Expression, baseCond llvm.Value, onTrue func(), onFalse func()) {
+	if len(children) == 0 {
+		c.compileCondExprBranchWithFailure(baseCond, nil, onTrue, onFalse)
+		return
+	}
+
+	child := children[0]
+	rest := children[1:]
+	if c.hasCondExprInTree(child) {
+		c.compileCondExprAlternative(child, baseCond, func() {
+			c.compileCondExprChildrenInFrame(rest, llvm.Value{}, onTrue, onFalse)
+		}, onFalse)
+		return
+	}
+
+	c.compileCondExprChildrenInFrame(rest, baseCond, onTrue, onFalse)
+}
+
+func (c *Compiler) compileCondExprAlternative(expr ast.Expression, baseCond llvm.Value, onTrue func(), onFalse func()) {
+	if logicalOr, ok := c.logicalOrCondExpr(expr); ok {
+		c.compileLogicalOrCondExprAlternative(logicalOr, baseCond, onTrue, onFalse)
+		return
+	}
+
+	if !c.hasLogicalOrCondExprInTree(expr) {
+		cond, temps := c.extractCondExprs(expr, baseCond, nil)
+		c.compileCondExprBranchWithFailure(cond, temps, onTrue, onFalse)
+		return
+	}
+
+	c.compileCondExprChildrenInFrame(ast.ExprChildren(expr), baseCond, func() {
+		if infix, ok := expr.(*ast.InfixExpression); ok {
+			info := c.ExprCache[key(c.FuncNameMangled, infix)]
+			if info != nil && info.HasCondScalar() && len(c.pendingLoopRanges(info.Ranges)) == 0 {
+				left := c.compileExpression(infix.Left, nil)
+				right := c.compileExpression(infix.Right, nil)
+
+				lhsSyms, cond := c.handleComparisons(infix.Operator, left, right, info, llvm.Value{})
+				c.requireCondLHSFrame()[key(c.FuncNameMangled, expr)] = lhsSyms
+				temps := []condTemp{{infix.Left, left}}
+				c.freeTemporary(infix.Right, right)
+				c.compileCondExprBranchWithFailure(cond, temps, onTrue, onFalse)
+				return
+			}
+		}
+
+		onTrue()
+	}, onFalse)
+}
+
+func (c *Compiler) withCondLHS(expr ast.Expression, syms []*Symbol, body func()) {
+	frame := c.requireCondLHSFrame()
+	exprKey := key(c.FuncNameMangled, expr)
+	old, hadOld := frame[exprKey]
+	frame[exprKey] = syms
+	body()
+	if hadOld {
+		frame[exprKey] = old
+		return
+	}
+	delete(frame, exprKey)
+}
+
+func (c *Compiler) compileLogicalOrCondExprAlternative(expr *ast.InfixExpression, baseCond llvm.Value, onTrue func(), onFalse func()) {
+	leftTrue := func() {
+		left := c.compileExpression(expr.Left, nil)
+		c.withCondLHS(expr, left, onTrue)
+	}
+	rightTrue := func() {
+		right := c.compileExpression(expr.Right, nil)
+		c.withCondLHS(expr, right, onTrue)
+	}
+
+	c.compileCondExprAlternative(expr.Left, baseCond, leftTrue, func() {
+		c.compileCondExprAlternative(expr.Right, baseCond, rightTrue, onFalse)
+	})
 }
 
 func (c *Compiler) isRangeDriverCond(expr ast.Expression) bool {

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -423,7 +423,7 @@ func (c *Compiler) logicalOrCondExpr(expr ast.Expression) (*ast.InfixExpression,
 	}
 
 	info := c.ExprCache[key(c.FuncNameMangled, expr)]
-	return infix, info != nil && info.HasFallbackOr()
+	return infix, info.HasFallbackOr()
 }
 
 func (c *Compiler) hasLogicalOrCondExprInTree(expr ast.Expression) bool {

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -476,7 +476,7 @@ func (c *Compiler) extractCondExprs(expr ast.Expression, cond llvm.Value, temps 
 	if infix, ok := expr.(*ast.InfixExpression); ok && info.HasCondScalar() && len(c.pendingLoopRanges(info.Ranges)) == 0 {
 		cond, temps = c.extractCondExprs(infix.Left, cond, temps)
 		cond, temps = c.extractCondExprs(infix.Right, cond, temps)
-		return c.extractCondExprSelf(infix, info, cond, temps)
+		return c.extractInfixCondExpr(infix, info, cond, temps)
 	}
 
 	// Not a conditional expression — recurse into children
@@ -486,7 +486,7 @@ func (c *Compiler) extractCondExprs(expr ast.Expression, cond llvm.Value, temps 
 	return cond, temps
 }
 
-func (c *Compiler) extractCondExprSelf(infix *ast.InfixExpression, info *ExprInfo, cond llvm.Value, temps []condTemp) (llvm.Value, []condTemp) {
+func (c *Compiler) extractInfixCondExpr(infix *ast.InfixExpression, info *ExprInfo, cond llvm.Value, temps []condTemp) (llvm.Value, []condTemp) {
 	left := c.compileExpression(infix.Left, nil)
 	right := c.compileExpression(infix.Right, nil)
 
@@ -612,7 +612,7 @@ func (c *Compiler) compileCondExprWithFailure(expr ast.Expression, baseCond llvm
 		if infix, ok := expr.(*ast.InfixExpression); ok {
 			info := c.ExprCache[key(c.FuncNameMangled, infix)]
 			if info != nil && info.HasCondScalar() && len(c.pendingLoopRanges(info.Ranges)) == 0 {
-				cond, temps := c.extractCondExprSelf(infix, info, llvm.Value{}, nil)
+				cond, temps := c.extractInfixCondExpr(infix, info, llvm.Value{}, nil)
 				c.compileCondExprBranch(cond, temps, onTrue, onFalse)
 				return
 			}

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -535,7 +535,7 @@ func (c *Compiler) compileCondExprValueInFrame(expr ast.Expression, baseCond llv
 	}
 
 	cond, temps := c.extractCondExprs(expr, baseCond, nil)
-	c.compileCondExprBranch(cond, temps, onTrue)
+	c.compileCondExprBranch(cond, temps, onTrue, func() {})
 }
 
 // compileOperandCondExprValue extracts conditional expressions from expr's
@@ -555,14 +555,10 @@ func (c *Compiler) compileOperandCondExprValue(expr ast.Expression, baseCond llv
 	for _, child := range ast.ExprChildren(expr) {
 		cond, temps = c.extractCondExprs(child, cond, temps)
 	}
-	c.compileCondExprBranch(cond, temps, onTrue)
+	c.compileCondExprBranch(cond, temps, onTrue, func() {})
 }
 
-func (c *Compiler) compileCondExprBranch(cond llvm.Value, temps []condTemp, onTrue func()) {
-	c.compileCondExprBranchWithFailure(cond, temps, onTrue, func() {})
-}
-
-func (c *Compiler) compileCondExprBranchWithFailure(cond llvm.Value, temps []condTemp, onTrue func(), onFalse func()) {
+func (c *Compiler) compileCondExprBranch(cond llvm.Value, temps []condTemp, onTrue func(), onFalse func()) {
 	if cond.IsNil() {
 		onTrue()
 		return
@@ -584,7 +580,7 @@ func (c *Compiler) compileCondExprBranchWithFailure(cond llvm.Value, temps []con
 
 func (c *Compiler) compileCondExprChildrenInFrame(children []ast.Expression, baseCond llvm.Value, onTrue func(), onFalse func()) {
 	if len(children) == 0 {
-		c.compileCondExprBranchWithFailure(baseCond, nil, onTrue, onFalse)
+		c.compileCondExprBranch(baseCond, nil, onTrue, onFalse)
 		return
 	}
 
@@ -608,7 +604,7 @@ func (c *Compiler) compileCondExprWithFailure(expr ast.Expression, baseCond llvm
 
 	if !c.hasLogicalOrCondExprInTree(expr) {
 		cond, temps := c.extractCondExprs(expr, baseCond, nil)
-		c.compileCondExprBranchWithFailure(cond, temps, onTrue, onFalse)
+		c.compileCondExprBranch(cond, temps, onTrue, onFalse)
 		return
 	}
 
@@ -617,7 +613,7 @@ func (c *Compiler) compileCondExprWithFailure(expr ast.Expression, baseCond llvm
 			info := c.ExprCache[key(c.FuncNameMangled, infix)]
 			if info != nil && info.HasCondScalar() && len(c.pendingLoopRanges(info.Ranges)) == 0 {
 				cond, temps := c.extractCondExprSelf(infix, info, llvm.Value{}, nil)
-				c.compileCondExprBranchWithFailure(cond, temps, onTrue, onFalse)
+				c.compileCondExprBranch(cond, temps, onTrue, onFalse)
 				return
 			}
 		}
@@ -636,7 +632,7 @@ func (c *Compiler) withCondLHS(expr ast.Expression, syms []*Symbol, body func())
 
 func (c *Compiler) compileLogicalOrCondExprWithFailure(expr *ast.InfixExpression, baseCond llvm.Value, onTrue func(), onFalse func()) {
 	if !baseCond.IsNil() {
-		c.compileCondExprBranchWithFailure(baseCond, nil, func() {
+		c.compileCondExprBranch(baseCond, nil, func() {
 			c.compileLogicalOrCondExprWithFailure(expr, llvm.Value{}, onTrue, onFalse)
 		}, onFalse)
 		return

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -630,9 +630,6 @@ func (c *Compiler) compileCondExprWithFailure(expr ast.Expression, baseCond llvm
 func (c *Compiler) withCondLHS(expr ast.Expression, syms []*Symbol, body func()) {
 	frame := c.requireCondLHSFrame()
 	exprKey := key(c.FuncNameMangled, expr)
-	if _, exists := frame[exprKey]; exists {
-		panic("internal: condLHS binding already active for expression")
-	}
 	frame[exprKey] = syms
 	defer delete(frame, exprKey)
 	body()

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/thiremani/pluto/ast"
-	"github.com/thiremani/pluto/token"
 	"tinygo.org/x/go-llvm"
 )
 
@@ -417,8 +416,8 @@ func (c *Compiler) hasCondExprInTree(expr ast.Expression) bool {
 }
 
 func (c *Compiler) logicalOrCondExpr(expr ast.Expression) (*ast.InfixExpression, bool) {
-	infix, ok := expr.(*ast.InfixExpression)
-	if !ok || infix.Operator != token.SYM_LOGICAL_OR {
+	infix, ok := ast.IsLogicalOr(expr)
+	if !ok {
 		return nil, false
 	}
 

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -415,7 +415,7 @@ func (c *Compiler) hasCondExprInTree(expr ast.Expression) bool {
 	return false
 }
 
-func (c *Compiler) logicalOrCondExpr(expr ast.Expression) (*ast.InfixExpression, bool) {
+func (c *Compiler) fallbackOrExpr(expr ast.Expression) (*ast.InfixExpression, bool) {
 	infix, ok := ast.IsLogicalOr(expr)
 	if !ok {
 		return nil, false
@@ -425,12 +425,12 @@ func (c *Compiler) logicalOrCondExpr(expr ast.Expression) (*ast.InfixExpression,
 	return infix, info.HasFallbackOr()
 }
 
-func (c *Compiler) hasLogicalOrCondExprInTree(expr ast.Expression) bool {
-	if _, ok := c.logicalOrCondExpr(expr); ok {
+func (c *Compiler) hasFallbackOrInTree(expr ast.Expression) bool {
+	if _, ok := c.fallbackOrExpr(expr); ok {
 		return true
 	}
 	for _, child := range ast.ExprChildren(expr) {
-		if c.hasLogicalOrCondExprInTree(child) {
+		if c.hasFallbackOrInTree(child) {
 			return true
 		}
 	}
@@ -462,31 +462,26 @@ func (c *Compiler) handleComparisons(op string, left, right []*Symbol, info *Exp
 	return lhsSyms, cond
 }
 
-// extractCondExprs walks the expression tree, evaluates each CondScalar
-// comparison, ANDs results into cond, and stores LHS values in the
-// statement-local condLHS map for substitution during later value compilation.
-// LHS temporaries are appended to temps so the caller can free them on the
-// false path.
+// extractCondExprs evaluates value-position comparisons and stores their LHS
+// values for substitution during later value compilation.
 func (c *Compiler) extractCondExprs(expr ast.Expression, cond llvm.Value, temps []condTemp) (llvm.Value, []condTemp) {
 	info := c.ExprCache[key(c.FuncNameMangled, expr)]
 
-	// Handle conditional expression (comparison in value position).
 	// Comparisons with ranges can be extracted only when all required iterators
 	// are already bound by an outer loop (no pending ranges).
 	if infix, ok := expr.(*ast.InfixExpression); ok && info.HasCondScalar() && len(c.pendingLoopRanges(info.Ranges)) == 0 {
 		cond, temps = c.extractCondExprs(infix.Left, cond, temps)
 		cond, temps = c.extractCondExprs(infix.Right, cond, temps)
-		return c.extractInfixCondExpr(infix, info, cond, temps)
+		return c.extractCondComparison(infix, info, cond, temps)
 	}
 
-	// Not a conditional expression — recurse into children
 	for _, child := range ast.ExprChildren(expr) {
 		cond, temps = c.extractCondExprs(child, cond, temps)
 	}
 	return cond, temps
 }
 
-func (c *Compiler) extractInfixCondExpr(infix *ast.InfixExpression, info *ExprInfo, cond llvm.Value, temps []condTemp) (llvm.Value, []condTemp) {
+func (c *Compiler) extractCondComparison(infix *ast.InfixExpression, info *ExprInfo, cond llvm.Value, temps []condTemp) (llvm.Value, []condTemp) {
 	left := c.compileExpression(infix.Left, nil)
 	right := c.compileExpression(infix.Right, nil)
 
@@ -495,8 +490,8 @@ func (c *Compiler) extractInfixCondExpr(infix *ast.InfixExpression, info *ExprIn
 
 	c.requireCondLHSFrame()[key(c.FuncNameMangled, infix)] = lhsSyms
 	temps = append(temps, condTemp{infix.Left, left})
-	// Free right-side temporaries (only used for comparison).
-	// Left-side values are retained in condLHS for later substitution.
+
+	// Right is comparison-only; left is retained for condLHS substitution.
 	c.freeTemporary(infix.Right, right)
 	return cond, temps
 }
@@ -517,36 +512,28 @@ func (c *Compiler) cleanupCondExprElse(temps []condTemp) {
 	}
 }
 
-// compileCondExprValue extracts cond-expr predicates for expr, branches through
-// value-position conditions, and compiles onTrue on admitted paths only. Plain
-// comparisons compose as AND; value-position logical OR tries the left operand
-// first and falls back to the right operand only on the left false path.
+// compileCondExprValue gates value-position cond expressions. Comparisons
+// compose as AND; fallback OR tries the right side only after the left fails.
 func (c *Compiler) compileCondExprValue(expr ast.Expression, baseCond llvm.Value, onTrue func()) {
 	c.pushCondLHSFrame()
 	defer c.popCondLHSFrame()
 
-	c.compileCondExprValueInFrame(expr, baseCond, onTrue)
-}
-
-func (c *Compiler) compileCondExprValueInFrame(expr ast.Expression, baseCond llvm.Value, onTrue func()) {
-	if c.hasLogicalOrCondExprInTree(expr) {
-		c.compileCondExprWithFailure(expr, baseCond, onTrue, func() {})
+	if c.hasFallbackOrInTree(expr) {
+		c.compileYield(expr, baseCond, onTrue, func() {})
 		return
 	}
 
 	cond, temps := c.extractCondExprs(expr, baseCond, nil)
-	c.compileCondExprBranch(cond, temps, onTrue, func() {})
+	c.branchCond(cond, temps, onTrue, func() {})
 }
 
-// compileOperandCondExprValue extracts conditional expressions from expr's
-// operands while leaving expr itself to the caller. Use this when the caller is
-// compiling the root operation into an already-seeded output slot.
-func (c *Compiler) compileOperandCondExprValue(expr ast.Expression, baseCond llvm.Value, onTrue func()) {
+// compileCondOperands leaves expr itself to the caller.
+func (c *Compiler) compileCondOperands(expr ast.Expression, baseCond llvm.Value, onTrue func()) {
 	c.pushCondLHSFrame()
 	defer c.popCondLHSFrame()
 
-	if c.hasLogicalOrCondExprInTree(expr) {
-		c.compileCondExprChildrenInFrame(ast.ExprChildren(expr), baseCond, onTrue, func() {})
+	if c.hasFallbackOrInTree(expr) {
+		c.compileChildYields(ast.ExprChildren(expr), baseCond, onTrue, func() {})
 		return
 	}
 
@@ -555,10 +542,10 @@ func (c *Compiler) compileOperandCondExprValue(expr ast.Expression, baseCond llv
 	for _, child := range ast.ExprChildren(expr) {
 		cond, temps = c.extractCondExprs(child, cond, temps)
 	}
-	c.compileCondExprBranch(cond, temps, onTrue, func() {})
+	c.branchCond(cond, temps, onTrue, func() {})
 }
 
-func (c *Compiler) compileCondExprBranch(cond llvm.Value, temps []condTemp, onTrue func(), onFalse func()) {
+func (c *Compiler) branchCond(cond llvm.Value, temps []condTemp, onTrue func(), onFalse func()) {
 	if cond.IsNil() {
 		onTrue()
 		return
@@ -578,42 +565,42 @@ func (c *Compiler) compileCondExprBranch(cond llvm.Value, temps []condTemp, onTr
 	c.builder.SetInsertPointAtEnd(contBlock)
 }
 
-func (c *Compiler) compileCondExprChildrenInFrame(children []ast.Expression, baseCond llvm.Value, onTrue func(), onFalse func()) {
+func (c *Compiler) compileChildYields(children []ast.Expression, baseCond llvm.Value, onTrue func(), onFalse func()) {
 	if len(children) == 0 {
-		c.compileCondExprBranch(baseCond, nil, onTrue, onFalse)
+		c.branchCond(baseCond, nil, onTrue, onFalse)
 		return
 	}
 
 	child := children[0]
 	rest := children[1:]
 	if c.hasCondExprInTree(child) {
-		c.compileCondExprWithFailure(child, baseCond, func() {
-			c.compileCondExprChildrenInFrame(rest, llvm.Value{}, onTrue, onFalse)
+		c.compileYield(child, baseCond, func() {
+			c.compileChildYields(rest, llvm.Value{}, onTrue, onFalse)
 		}, onFalse)
 		return
 	}
 
-	c.compileCondExprChildrenInFrame(rest, baseCond, onTrue, onFalse)
+	c.compileChildYields(rest, baseCond, onTrue, onFalse)
 }
 
-func (c *Compiler) compileCondExprWithFailure(expr ast.Expression, baseCond llvm.Value, onTrue func(), onFalse func()) {
-	if logicalOr, ok := c.logicalOrCondExpr(expr); ok {
-		c.compileLogicalOrCondExprWithFailure(logicalOr, baseCond, onTrue, onFalse)
+func (c *Compiler) compileYield(expr ast.Expression, baseCond llvm.Value, onTrue func(), onFalse func()) {
+	if logicalOr, ok := c.fallbackOrExpr(expr); ok {
+		c.compileFallbackOr(logicalOr, baseCond, onTrue, onFalse)
 		return
 	}
 
-	if !c.hasLogicalOrCondExprInTree(expr) {
+	if !c.hasFallbackOrInTree(expr) {
 		cond, temps := c.extractCondExprs(expr, baseCond, nil)
-		c.compileCondExprBranch(cond, temps, onTrue, onFalse)
+		c.branchCond(cond, temps, onTrue, onFalse)
 		return
 	}
 
-	c.compileCondExprChildrenInFrame(ast.ExprChildren(expr), baseCond, func() {
+	c.compileChildYields(ast.ExprChildren(expr), baseCond, func() {
 		if infix, ok := expr.(*ast.InfixExpression); ok {
 			info := c.ExprCache[key(c.FuncNameMangled, infix)]
 			if info != nil && info.HasCondScalar() && len(c.pendingLoopRanges(info.Ranges)) == 0 {
-				cond, temps := c.extractInfixCondExpr(infix, info, llvm.Value{}, nil)
-				c.compileCondExprBranch(cond, temps, onTrue, onFalse)
+				cond, temps := c.extractCondComparison(infix, info, llvm.Value{}, nil)
+				c.branchCond(cond, temps, onTrue, onFalse)
 				return
 			}
 		}
@@ -630,10 +617,10 @@ func (c *Compiler) withCondLHS(expr ast.Expression, syms []*Symbol, body func())
 	body()
 }
 
-func (c *Compiler) compileLogicalOrCondExprWithFailure(expr *ast.InfixExpression, baseCond llvm.Value, onTrue func(), onFalse func()) {
+func (c *Compiler) compileFallbackOr(expr *ast.InfixExpression, baseCond llvm.Value, onTrue func(), onFalse func()) {
 	if !baseCond.IsNil() {
-		c.compileCondExprBranch(baseCond, nil, func() {
-			c.compileLogicalOrCondExprWithFailure(expr, llvm.Value{}, onTrue, onFalse)
+		c.branchCond(baseCond, nil, func() {
+			c.compileFallbackOr(expr, llvm.Value{}, onTrue, onFalse)
 		}, onFalse)
 		return
 	}
@@ -647,8 +634,8 @@ func (c *Compiler) compileLogicalOrCondExprWithFailure(expr *ast.InfixExpression
 		c.withCondLHS(expr, right, onTrue)
 	}
 
-	c.compileCondExprWithFailure(expr.Left, llvm.Value{}, leftTrue, func() {
-		c.compileCondExprWithFailure(expr.Right, llvm.Value{}, rightTrue, onFalse)
+	c.compileYield(expr.Left, llvm.Value{}, leftTrue, func() {
+		c.compileYield(expr.Right, llvm.Value{}, rightTrue, onFalse)
 	})
 }
 

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -423,7 +423,7 @@ func (c *Compiler) logicalOrCondExpr(expr ast.Expression) (*ast.InfixExpression,
 	}
 
 	info := c.ExprCache[key(c.FuncNameMangled, expr)]
-	return infix, info != nil && info.HasCondOr()
+	return infix, info != nil && info.HasFallbackOr()
 }
 
 func (c *Compiler) hasLogicalOrCondExprInTree(expr ast.Expression) bool {

--- a/compiler/operators.go
+++ b/compiler/operators.go
@@ -650,18 +650,6 @@ var defaultOps = map[opKey]opFunc{
 		return
 	},
 
-	// Logical OR
-	{Operator: token.SYM_LOGICAL_OR, LeftType: I1, RightType: I1}: func(c *Compiler, left, right *Symbol, compile bool) (s *Symbol) {
-		s = &Symbol{}
-		s.Type = left.Type
-		if !compile {
-			return
-		}
-
-		s.Val = c.builder.CreateOr(left.Val, right.Val, "or_cond")
-		return
-	},
-
 	// Bitwise XOR
 	{Operator: token.SYM_XOR, LeftType: I64, RightType: I64}: func(c *Compiler, left, right *Symbol, compile bool) (s *Symbol) {
 		s = &Symbol{}

--- a/compiler/operators.go
+++ b/compiler/operators.go
@@ -650,6 +650,18 @@ var defaultOps = map[opKey]opFunc{
 		return
 	},
 
+	// Logical OR
+	{Operator: token.SYM_LOGICAL_OR, LeftType: I1, RightType: I1}: func(c *Compiler, left, right *Symbol, compile bool) (s *Symbol) {
+		s = &Symbol{}
+		s.Type = left.Type
+		if !compile {
+			return
+		}
+
+		s.Val = c.builder.CreateOr(left.Val, right.Val, "or_cond")
+		return
+	},
+
 	// Bitwise XOR
 	{Operator: token.SYM_XOR, LeftType: I64, RightType: I64}: func(c *Compiler, left, right *Symbol, compile bool) (s *Symbol) {
 		s = &Symbol{}

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1509,6 +1509,9 @@ func (ts *TypeSolver) typeLogicalOrExpression(expr *ast.InfixExpression, left, r
 	rightInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Right)]
 
 	if ts.InValueExpr {
+		// Value-position OR is asymmetric: the left operand must be able to
+		// fail, while the right operand may be another condition or a plain
+		// fallback value.
 		if leftInfo == nil || !leftInfo.HasCondExpr() {
 			ts.Errors = append(ts.Errors, &token.CompileError{
 				Token: expr.Token,

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -22,6 +22,7 @@ const (
 	CondNone   CondMode = iota // Normal expression (not a comparison in value position)
 	CondScalar                 // Scalar: extract LHS value, branch on condition
 	CondArray                  // Array: element-wise filter, keep LHS where condition holds
+	CondOr                     // Logical OR in value position: first true operand wins
 )
 
 type ExprInfo struct {
@@ -41,6 +42,24 @@ type ExprInfo struct {
 func (info *ExprInfo) HasCondScalar() bool {
 	for _, m := range info.CompareModes {
 		if m == CondScalar {
+			return true
+		}
+	}
+	return false
+}
+
+func (info *ExprInfo) HasCondOr() bool {
+	for _, m := range info.CompareModes {
+		if m == CondOr {
+			return true
+		}
+	}
+	return false
+}
+
+func (info *ExprInfo) HasCondExpr() bool {
+	for _, m := range info.CompareModes {
+		if m == CondScalar || m == CondOr {
 			return true
 		}
 	}
@@ -1454,6 +1473,89 @@ func (ts *TypeSolver) typeInfixSlot(expr *ast.InfixExpression, leftType, rightTy
 	return resultType, CondNone
 }
 
+func (ts *TypeSolver) logicalOrValueType(leftType, rightType Type, tok token.Token) Type {
+	if ptr, ok := leftType.(Ptr); ok {
+		leftType = ptr.Elem
+	}
+	if ptr, ok := rightType.(Ptr); ok {
+		rightType = ptr.Elem
+	}
+
+	switch {
+	case leftType.Kind() == UnresolvedKind:
+		return rightType
+	case rightType.Kind() == UnresolvedKind:
+		return leftType
+	case leftType.Kind() == StrKind && rightType.Kind() == StrKind:
+		return mergeStringFlavor(leftType, rightType)
+	case TypeEqual(leftType, rightType):
+		return leftType
+	default:
+		ts.Errors = append(ts.Errors, &token.CompileError{
+			Token: tok,
+			Msg:   fmt.Sprintf("logical OR value operands must have matching output types, got %s and %s", leftType, rightType),
+		})
+		return Unresolved{}
+	}
+}
+
+func isI1(t Type) bool {
+	intType, ok := t.(Int)
+	return ok && intType.Width == 1
+}
+
+func (ts *TypeSolver) typeLogicalOrExpression(expr *ast.InfixExpression, left, right []Type) []Type {
+	leftInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Left)]
+	rightInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Right)]
+
+	if ts.InValueExpr {
+		if leftInfo == nil || !leftInfo.HasCondExpr() {
+			ts.Errors = append(ts.Errors, &token.CompileError{
+				Token: expr.Token,
+				Msg:   "logical OR in value position requires a conditional left operand",
+			})
+		}
+
+		types := make([]Type, len(left))
+		compareModes := make([]CondMode, len(left))
+		for i := range left {
+			types[i] = ts.logicalOrValueType(left[i], right[i], expr.Token)
+			compareModes[i] = CondOr
+		}
+
+		ts.ExprCache[key(ts.FuncNameMangled, expr)] = &ExprInfo{
+			OutTypes:     types,
+			ExprLen:      len(types),
+			HasRanges:    (leftInfo != nil && leftInfo.HasRanges) || (rightInfo != nil && rightInfo.HasRanges),
+			CompareModes: compareModes,
+		}
+		return types
+	}
+
+	types := []Type{I1}
+	if len(left) != 1 {
+		ts.Errors = append(ts.Errors, &token.CompileError{
+			Token: expr.Token,
+			Msg:   fmt.Sprintf("logical OR condition operands must produce a single value, got %d", len(left)),
+		})
+		types = []Type{Unresolved{}}
+	} else if left[0].Kind() != UnresolvedKind && right[0].Kind() != UnresolvedKind && (!isI1(left[0]) || !isI1(right[0])) {
+		ts.Errors = append(ts.Errors, &token.CompileError{
+			Token: expr.Token,
+			Msg:   fmt.Sprintf("logical OR requires condition operands, got %s and %s", left[0], right[0]),
+		})
+		types = []Type{Unresolved{}}
+	}
+
+	ts.ExprCache[key(ts.FuncNameMangled, expr)] = &ExprInfo{
+		OutTypes:     types,
+		ExprLen:      len(types),
+		HasRanges:    (leftInfo != nil && leftInfo.HasRanges) || (rightInfo != nil && rightInfo.HasRanges),
+		CompareModes: make([]CondMode, len(types)),
+	}
+	return types
+}
+
 // TypeInfixExpression returns output types of infix expression
 // If either left or right operands are pointers, it will dereference them
 // This is because pointers are automatically dereferenced
@@ -1469,6 +1571,10 @@ func (ts *TypeSolver) TypeInfixExpression(expr *ast.InfixExpression) (types []Ty
 		types = []Type{Unresolved{}}
 		ts.ExprCache[key(ts.FuncNameMangled, expr)] = &ExprInfo{OutTypes: types, ExprLen: 1}
 		return
+	}
+
+	if expr.Operator == token.SYM_LOGICAL_OR {
+		return ts.typeLogicalOrExpression(expr, left, right)
 	}
 
 	isValueCmp := ts.InValueExpr && expr.Token.IsComparison()

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1499,11 +1499,6 @@ func (ts *TypeSolver) logicalOrValueType(leftType, rightType Type, tok token.Tok
 	}
 }
 
-func isI1(t Type) bool {
-	intType, ok := t.(Int)
-	return ok && intType.Width == 1
-}
-
 func (ts *TypeSolver) typeLogicalOrExpression(expr *ast.InfixExpression, left, right []Type) []Type {
 	leftInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Left)]
 	rightInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Right)]
@@ -1542,7 +1537,7 @@ func (ts *TypeSolver) typeLogicalOrExpression(expr *ast.InfixExpression, left, r
 			Msg:   fmt.Sprintf("logical OR condition operands must produce a single value, got %d", len(left)),
 		})
 		types = []Type{Unresolved{}}
-	} else if left[0].Kind() != UnresolvedKind && right[0].Kind() != UnresolvedKind && (!isI1(left[0]) || !isI1(right[0])) {
+	} else if left[0].Kind() != UnresolvedKind && right[0].Kind() != UnresolvedKind && (!IsI1(left[0]) || !IsI1(right[0])) {
 		ts.Errors = append(ts.Errors, &token.CompileError{
 			Token: expr.Token,
 			Msg:   fmt.Sprintf("logical OR requires condition operands, got %s and %s", left[0], right[0]),

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1573,7 +1573,7 @@ func (ts *TypeSolver) TypeInfixExpression(expr *ast.InfixExpression) (types []Ty
 		return
 	}
 
-	if _, isLogicalOr := ast.IsLogicalOr(expr); isLogicalOr {
+	if expr.IsLogicalOr() {
 		return ts.typeLogicalOrExpression(expr, left, right)
 	}
 

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1539,12 +1539,18 @@ func (ts *TypeSolver) typeLogicalOrExpression(expr *ast.InfixExpression, left, r
 			Msg:   fmt.Sprintf("logical OR condition operands must produce a single value, got %d", len(left)),
 		})
 		types = []Type{Unresolved{}}
-	} else if left[0].Kind() != UnresolvedKind && right[0].Kind() != UnresolvedKind && (!IsI1(left[0]) || !IsI1(right[0])) {
-		ts.Errors = append(ts.Errors, &token.CompileError{
-			Token: expr.Token,
-			Msg:   fmt.Sprintf("logical OR requires condition operands, got %s and %s", left[0], right[0]),
-		})
-		types = []Type{Unresolved{}}
+	} else {
+		// Validate the i1 requirement only once both operand types are known;
+		// an unresolved operand may still resolve to i1 on a later solver pass.
+		bothResolved := left[0].Kind() != UnresolvedKind && right[0].Kind() != UnresolvedKind
+		bothConditions := IsI1(left[0]) && IsI1(right[0])
+		if bothResolved && !bothConditions {
+			ts.Errors = append(ts.Errors, &token.CompileError{
+				Token: expr.Token,
+				Msg:   fmt.Sprintf("logical OR requires condition operands, got %s and %s", left[0], right[0]),
+			})
+			types = []Type{Unresolved{}}
+		}
 	}
 
 	ts.ExprCache[key(ts.FuncNameMangled, expr)] = &ExprInfo{

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1506,7 +1506,9 @@ func (ts *TypeSolver) typeLogicalOrExpression(expr *ast.InfixExpression, left, r
 	if ts.InValueExpr {
 		// Value-position OR is asymmetric: the left operand must be able to
 		// fail, while the right operand may be another condition or a plain
-		// fallback value.
+		// fallback value. There is no matching value-position && because
+		// chained comparisons already refine a yielded value, and comma
+		// conditions provide statement-position AND.
 		if leftInfo == nil || !leftInfo.HasCondExpr() {
 			ts.Errors = append(ts.Errors, &token.CompileError{
 				Token: expr.Token,

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1573,7 +1573,7 @@ func (ts *TypeSolver) TypeInfixExpression(expr *ast.InfixExpression) (types []Ty
 		return
 	}
 
-	if expr.Operator == token.SYM_LOGICAL_OR {
+	if _, isLogicalOr := ast.IsLogicalOr(expr); isLogicalOr {
 		return ts.typeLogicalOrExpression(expr, left, right)
 	}
 

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -22,7 +22,7 @@ const (
 	CondNone   CondMode = iota // Normal expression (not a comparison in value position)
 	CondScalar                 // Scalar: extract LHS value, branch on condition
 	CondArray                  // Array: element-wise filter, keep LHS where condition holds
-	CondOr                     // Logical OR in value position: first true operand wins
+	CondOr                     // Fallback OR in value position: first true operand wins
 )
 
 type ExprInfo struct {
@@ -48,7 +48,7 @@ func (info *ExprInfo) HasCondScalar() bool {
 	return false
 }
 
-func (info *ExprInfo) HasCondOr() bool {
+func (info *ExprInfo) HasFallbackOr() bool {
 	for _, m := range info.CompareModes {
 		if m == CondOr {
 			return true

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -565,7 +565,7 @@ func TestLogicalOrDiagnostics(t *testing.T) {
 		{
 			name:        "FallbackTypesMustMatch",
 			script:      "a = 1\nx = a > 0 || \"fallback\"",
-			expectError: "logical OR value operands must have matching output types, got I64 and StrG",
+			expectError: "logical OR value operands must have matching output types, got I64 and Str",
 		},
 		{
 			name:        "ConditionOperandsMustBeI1",

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -548,6 +548,58 @@ func TestScalarConditionEmitsTypeDiagnostic(t *testing.T) {
 	require.Contains(t, ts.Errors[0].Msg, "statement condition must be a comparison or bare range/array-range driver, got I64")
 }
 
+func TestLogicalOrDiagnostics(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+
+	cases := []struct {
+		name        string
+		script      string
+		expectError string
+	}{
+		{
+			name:        "ValueOrRequiresConditionalLeft",
+			script:      "x = 1 || 2",
+			expectError: "logical OR in value position requires a conditional left operand",
+		},
+		{
+			name:        "FallbackTypesMustMatch",
+			script:      "a = 1\nx = a > 0 || \"fallback\"",
+			expectError: "logical OR value operands must have matching output types, got I64 and StrG",
+		},
+		{
+			name:        "ConditionOperandsMustBeI1",
+			script:      "a = 1\nb = 2\nx = a > 0 || b 7",
+			expectError: "logical OR requires condition operands, got I1 and I64",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cc := NewCodeCompiler(ctx, tc.name, "", ast.NewCode())
+			require.Empty(t, cc.Compile())
+
+			sl := lexer.New(tc.name+".spt", tc.script)
+			sp := parser.NewScriptParser(sl)
+			program := sp.Parse()
+			require.Empty(t, sp.Errors(), "unexpected parse errors: %v", sp.Errors())
+
+			sc := NewScriptCompiler(ctx, program, cc, make(map[string]*Func), make(map[ExprKey]*ExprInfo))
+			ts := NewTypeSolver(sc)
+			ts.Solve()
+
+			found := false
+			for _, err := range ts.Errors {
+				if strings.Contains(err.Msg, tc.expectError) {
+					found = true
+					break
+				}
+			}
+			require.Truef(t, found, "expected error containing %q, got: %v", tc.expectError, ts.Errors)
+		})
+	}
+}
+
 func TestScalarArrayComparisonInValuePositionIsFilter(t *testing.T) {
 	ctx := llvm.NewContext()
 	cc := NewCodeCompiler(ctx, "scalarArrayComparisonValue", "", ast.NewCode())

--- a/compiler/types.go
+++ b/compiler/types.go
@@ -99,6 +99,11 @@ func (i Int) Kind() Kind {
 func (i Int) Mangle() string { return i.String() }
 func (i Int) Key() Type      { return i }
 
+func IsI1(t Type) bool {
+	intType, ok := t.(Int)
+	return ok && intType.Width == 1
+}
+
 // Float represents a floating-point type with a given precision.
 type Float struct {
 	Width uint32 // e.g. 32, 64

--- a/compiler/types.go
+++ b/compiler/types.go
@@ -136,7 +136,10 @@ func (p Ptr) Kind() Kind {
 // These strings are never freed and cannot be concatenated.
 type StrG struct{}
 
-func (s StrG) String() string { return "StrG" }
+// String is the user-facing name; the global/heap flavor is an internal
+// detail carried only by Mangle (for specialization identity), not shown
+// in diagnostics.
+func (s StrG) String() string { return "Str" }
 func (s StrG) Kind() Kind     { return StrKind }
 func (s StrG) Mangle() string { return "StrG" }
 func (s StrG) Key() Type      { return s }
@@ -145,7 +148,8 @@ func (s StrG) Key() Type      { return s }
 // These strings must be freed and can be concatenated.
 type StrH struct{}
 
-func (s StrH) String() string { return "StrH" }
+// String is the user-facing name; see StrG.String. Mangle keeps the flavor.
+func (s StrH) String() string { return "Str" }
 func (s StrH) Kind() Kind     { return StrKind }
 func (s StrH) Mangle() string { return "StrH" }
 func (s StrH) Key() Type      { return s }

--- a/docs/Pluto Conditional Value Semantics.md
+++ b/docs/Pluto Conditional Value Semantics.md
@@ -78,21 +78,22 @@ a = 0
 a < 2 || 7           # a < 2 is true -> yields a (0), not 7
 ```
 
-## Parentheses and local resolution
+## Parentheses group the condition
 
 At the top of a statement the `=` separates condition from value, so no
 parentheses are needed (`lhs = cond value`). Inside a larger expression,
-parentheses mark where the condition ends and the value begins.
-
-A conditional resolves **locally** — to its value, to zero, or to its `||`
-fallback. It does not reach back out to an enclosing operator. To choose a
-fallback for a larger expression, put the `||` (or the gate) where you want the
-decision:
+parentheses mark where a conditional ends, choosing what the gate and `||`
+attach to:
 
 ```pluto
-(a > 2 10) < 3 || 5    # a <= 2: (a > 2 10) is 0, then 0 < 3 is true -> 0
-a > 2  (10 < 3 || 5)   # gate on a; fallback chosen inside
+x = a > 3  b < 5 || 10     # gate a > 3 (keep-old); || is the fallback for b < 5
+x = (a > 3 b < 5) || 10    # one conditional; || is the fallback for a > 3
 ```
+
+In the first, `a > 3` gates the statement and `|| 10` catches `b < 5`. In the
+second, `(a > 3 b < 5)` is a single conditional, so `|| 10` fires when `a > 3`
+fails, while a failing `b < 5` resolves locally to zero. A conditional resolves
+locally and never reaches back out to an enclosing operator.
 
 ## Arrays
 
@@ -102,6 +103,13 @@ zero, and `||` overrides.
 ```pluto
 [i > 2]          # failed cells are 0   (zero-fill)
 [i > 2 || -1]    # failed cells are -1
+```
+
+Spacing separates cells, so parentheses also control cell count:
+
+```pluto
+[a > 3  b < 5 || 10]     # two cells
+[(a > 3 b < 5) || 10]    # one cell
 ```
 
 A filter is different: `arr > k` drops elements that fail rather than zeroing

--- a/docs/Pluto Conditional Value Semantics.md
+++ b/docs/Pluto Conditional Value Semantics.md
@@ -62,13 +62,18 @@ transparency.)
 
 ## Fallback `||` overrides the zero
 
-`||` supplies a chosen value when the condition fails, instead of zero. It is
-part of the conditional and is left-biased:
+`||` supplies a chosen value when the condition fails, instead of zero. Its left
+operand must be a conditional (able to fail); it is left-biased and chains:
 
 ```pluto
-y > 2 3 || 7         # 3 when y > 2, else 7
+a > 2 || 7           # a when a > 2, else 7
 a > 2 || b > 2 || 9  # a if a>2, else b if b>2, else 9
 ```
+
+To fall back from an explicit value, parenthesize the conditional: `(a > 2 3) || 7`
+yields `3` when `a > 2`, else `7`. Unparenthesized, `x = a > 2 3 || 7` is an error —
+`a > 2` gates the statement, leaving `3 || 7` as a value-position `||` whose left
+operand cannot fail.
 
 `||` keys off the condition, not the resolved value, so a true condition whose
 value happens to be zero is kept:

--- a/docs/Pluto Conditional Value Semantics.md
+++ b/docs/Pluto Conditional Value Semantics.md
@@ -1,0 +1,129 @@
+# Pluto Conditional Value Semantics
+
+How conditions behave depending on where they appear: as a statement gate, or as
+a value inside an expression. This is the general model under
+[Pluto Range Semantics](Pluto%20Range%20Semantics.md).
+
+## Two positions, two meanings
+
+A condition means different things in two places:
+
+1. **Statement gate** — left of the value in `lhs = cond value`. Gates the whole
+   assignment.
+2. **Value position** — inside the value expression, e.g. `x * (y > 2 3)`.
+   Produces a value.
+
+The rule, in one line: **conditions left of the value gate the statement and keep
+the old value on failure; conditions inside the value are temporaries that
+resolve to zero (or a `||` fallback) on failure.**
+
+## Statement gate: keep-old
+
+A condition before the value gates the assignment. If it fails, no assignment
+happens: an existing variable keeps its value, a new variable is zero.
+
+```pluto
+old = 99
+old = b > 2  x * 3    # b <= 2 -> old stays 99
+                      # b >  2 -> old = x * 3
+
+new = b > 2  x * 3    # b <= 2 -> new = 0
+```
+
+Multiple conditions separated by commas are ANDed; all must hold.
+
+## Value position: a temporary, zero on false
+
+A conditional inside the value is a computed temporary. It yields its value when
+the condition holds, and the zero value when it does not — exactly like a fresh
+variable.
+
+```pluto
+y > 2 3      # 3 when y > 2, else 0
+y > 2        # y when y > 2, else 0   (the value is the left operand)
+```
+
+So it composes like any value:
+
+```pluto
+z = x * (y > 2 3)     # y >  2 -> z = x * 3
+                      # y <= 2 -> z = x * 0 = 0
+```
+
+This is identical to naming the temporary first:
+
+```pluto
+tmp = y > 2 3         # tmp = 3 or 0
+z   = x * tmp
+```
+
+Storing a conditional and inlining it behave the same. (Referential
+transparency.)
+
+## Fallback `||` overrides the zero
+
+`||` supplies a chosen value when the condition fails, instead of zero. It is
+part of the conditional and is left-biased:
+
+```pluto
+y > 2 3 || 7         # 3 when y > 2, else 7
+a > 2 || b > 2 || 9  # a if a>2, else b if b>2, else 9
+```
+
+`||` keys off the condition, not the resolved value, so a true condition whose
+value happens to be zero is kept:
+
+```pluto
+a = 0
+a < 2 || 7           # a < 2 is true -> yields a (0), not 7
+```
+
+## Parentheses and local resolution
+
+At the top of a statement the `=` separates condition from value, so no
+parentheses are needed (`lhs = cond value`). Inside a larger expression,
+parentheses mark where the condition ends and the value begins.
+
+A conditional resolves **locally** — to its value, to zero, or to its `||`
+fallback. It does not reach back out to an enclosing operator. To choose a
+fallback for a larger expression, put the `||` (or the gate) where you want the
+decision:
+
+```pluto
+(a > 2 10) < 3 || 5    # a <= 2: (a > 2 10) is 0, then 0 < 3 is true -> 0
+a > 2  (10 < 3 || 5)   # gate on a; fallback chosen inside
+```
+
+## Arrays
+
+A collector cell is a value position, so the same rule applies: a failed cell is
+zero, and `||` overrides.
+
+```pluto
+[i > 2]          # failed cells are 0   (zero-fill)
+[i > 2 || -1]    # failed cells are -1
+```
+
+A filter is different: `arr > k` drops elements that fail rather than zeroing
+them. See [Pluto Range Semantics](Pluto%20Range%20Semantics.md).
+
+## Why this model
+
+- **Referential transparency:** a value-position conditional equals a named
+  temporary, so storing and inlining never differ.
+- **Keep-old stays explicit:** it is provided by the statement gate, not hidden
+  inside value-position conditionals.
+- **Simple lowering:** a value-position conditional is a `select` between the
+  value and zero (or the `||` fallback) — no expression-wide branching.
+
+## Status
+
+- **Implemented:** statement gates (keep-old); `||` fallback in value and
+  condition position; value-position comparisons (yield the left operand);
+  collector zero-fill; array filters.
+- **Planned change:** nested value-position comparisons currently keep-old by
+  propagating out of the expression; the model above resolves them locally to
+  zero, matching a named temporary.
+- **Not yet implemented:** the parenthesized `(cond value)` form with an explicit
+  value, and per-cell conditionals inside array literals
+  (`[(a > 2 || 5) 7 (b > 7 || c)]`).

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -17,6 +17,7 @@ const (
 	LOWEST      = 0.0 + iota // iota works with floats when used in a float expression
 	ASSIGN                   // =
 	COMMA                    // ,
+	LOGICAL_OR               // ||
 	BITWISE_OR               // |
 	BITWISE_XOR              // ⊕
 	BITWISE_AND              // &
@@ -33,31 +34,32 @@ const (
 
 // leftBindingPower: how strongly an operator binds to its left operand
 var leftBindingPower = map[string]float64{
-	token.SYM_ASSIGN:   ASSIGN,
-	token.SYM_COMMA:    COMMA,
-	token.SYM_OR:       BITWISE_OR,
-	token.SYM_XOR:      BITWISE_XOR,
-	token.SYM_AND:      BITWISE_AND,
-	token.SYM_SHL:      SHIFT,
-	token.SYM_SHR:      SHIFT,
-	token.SYM_ASR:      SHIFT,
-	token.SYM_ADD:      SUM,
-	token.SYM_SUB:      SUM,
-	token.SYM_CONCAT:   SUM, // ⊕ array concatenation
-	token.SYM_MUL:      PRODUCT,
-	token.SYM_DIV:      PRODUCT,
-	token.SYM_QUO:      PRODUCT,
-	token.SYM_MOD:      PRODUCT,
-	token.SYM_IMPL_MUL: EXP - 0.25, // 8.75: Between RBP(^)=8.5 and EXP=9, allows ⋅ in exponents but not on left of ^
-	token.SYM_EXP:      EXP,
-	token.SYM_COLON:    COLON,
-	token.SYM_EQL:      LESSGREATER,
-	token.SYM_LSS:      LESSGREATER,
-	token.SYM_GTR:      LESSGREATER,
-	token.SYM_NEQ:      LESSGREATER,
-	token.SYM_LEQ:      LESSGREATER,
-	token.SYM_GEQ:      LESSGREATER,
-	token.SYM_LPAREN:   CALL,
+	token.SYM_ASSIGN:     ASSIGN,
+	token.SYM_COMMA:      COMMA,
+	token.SYM_LOGICAL_OR: LOGICAL_OR,
+	token.SYM_OR:         BITWISE_OR,
+	token.SYM_XOR:        BITWISE_XOR,
+	token.SYM_AND:        BITWISE_AND,
+	token.SYM_SHL:        SHIFT,
+	token.SYM_SHR:        SHIFT,
+	token.SYM_ASR:        SHIFT,
+	token.SYM_ADD:        SUM,
+	token.SYM_SUB:        SUM,
+	token.SYM_CONCAT:     SUM, // ⊕ array concatenation
+	token.SYM_MUL:        PRODUCT,
+	token.SYM_DIV:        PRODUCT,
+	token.SYM_QUO:        PRODUCT,
+	token.SYM_MOD:        PRODUCT,
+	token.SYM_IMPL_MUL:   EXP - 0.25, // 8.75: Between RBP(^)=8.5 and EXP=9, allows ⋅ in exponents but not on left of ^
+	token.SYM_EXP:        EXP,
+	token.SYM_COLON:      COLON,
+	token.SYM_EQL:        LESSGREATER,
+	token.SYM_LSS:        LESSGREATER,
+	token.SYM_GTR:        LESSGREATER,
+	token.SYM_NEQ:        LESSGREATER,
+	token.SYM_LEQ:        LESSGREATER,
+	token.SYM_GEQ:        LESSGREATER,
+	token.SYM_LPAREN:     CALL,
 }
 
 // rightBindingPower: how strongly an operator binds to its right operand
@@ -125,6 +127,7 @@ func New(l *lexer.Lexer) *StmtParser {
 	p.infixParseFns = make(map[string]infixParseFn)
 	p.registerInfix(token.SYM_COLON, p.parseRangeLiteral)
 
+	p.registerInfix(token.SYM_LOGICAL_OR, p.parseInfixExpression)
 	p.registerInfix(token.SYM_OR, p.parseInfixExpression)
 	p.registerInfix(token.SYM_XOR, p.parseInfixExpression)
 	p.registerInfix(token.SYM_AND, p.parseInfixExpression)
@@ -786,6 +789,10 @@ func (p *StmtParser) parseLetStatement(identList []*ast.Identifier) *ast.LetStat
 func (p *StmtParser) isCondition(exp ast.Expression) bool {
 	if exp.Tok().IsComparison() {
 		return true
+	}
+
+	if infix, ok := exp.(*ast.InfixExpression); ok && infix.Operator == token.SYM_LOGICAL_OR {
+		return p.isCondition(infix.Left) && p.isCondition(infix.Right)
 	}
 
 	switch exp.(type) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -17,7 +17,7 @@ const (
 	LOWEST      = 0.0 + iota // iota works with floats when used in a float expression
 	ASSIGN                   // =
 	COMMA                    // ,
-	LOGICAL_OR               // ||
+	COND_OR                  // ||
 	BITWISE_OR               // |
 	BITWISE_XOR              // ⊕
 	BITWISE_AND              // &
@@ -34,32 +34,32 @@ const (
 
 // leftBindingPower: how strongly an operator binds to its left operand
 var leftBindingPower = map[string]float64{
-	token.SYM_ASSIGN:     ASSIGN,
-	token.SYM_COMMA:      COMMA,
-	token.SYM_LOGICAL_OR: LOGICAL_OR,
-	token.SYM_OR:         BITWISE_OR,
-	token.SYM_XOR:        BITWISE_XOR,
-	token.SYM_AND:        BITWISE_AND,
-	token.SYM_SHL:        SHIFT,
-	token.SYM_SHR:        SHIFT,
-	token.SYM_ASR:        SHIFT,
-	token.SYM_ADD:        SUM,
-	token.SYM_SUB:        SUM,
-	token.SYM_CONCAT:     SUM, // ⊕ array concatenation
-	token.SYM_MUL:        PRODUCT,
-	token.SYM_DIV:        PRODUCT,
-	token.SYM_QUO:        PRODUCT,
-	token.SYM_MOD:        PRODUCT,
-	token.SYM_IMPL_MUL:   EXP - 0.25, // 8.75: Between RBP(^)=8.5 and EXP=9, allows ⋅ in exponents but not on left of ^
-	token.SYM_EXP:        EXP,
-	token.SYM_COLON:      COLON,
-	token.SYM_EQL:        LESSGREATER,
-	token.SYM_LSS:        LESSGREATER,
-	token.SYM_GTR:        LESSGREATER,
-	token.SYM_NEQ:        LESSGREATER,
-	token.SYM_LEQ:        LESSGREATER,
-	token.SYM_GEQ:        LESSGREATER,
-	token.SYM_LPAREN:     CALL,
+	token.SYM_ASSIGN:   ASSIGN,
+	token.SYM_COMMA:    COMMA,
+	token.SYM_COND_OR:  COND_OR,
+	token.SYM_OR:       BITWISE_OR,
+	token.SYM_XOR:      BITWISE_XOR,
+	token.SYM_AND:      BITWISE_AND,
+	token.SYM_SHL:      SHIFT,
+	token.SYM_SHR:      SHIFT,
+	token.SYM_ASR:      SHIFT,
+	token.SYM_ADD:      SUM,
+	token.SYM_SUB:      SUM,
+	token.SYM_CONCAT:   SUM, // ⊕ array concatenation
+	token.SYM_MUL:      PRODUCT,
+	token.SYM_DIV:      PRODUCT,
+	token.SYM_QUO:      PRODUCT,
+	token.SYM_MOD:      PRODUCT,
+	token.SYM_IMPL_MUL: EXP - 0.25, // 8.75: Between RBP(^)=8.5 and EXP=9, allows ⋅ in exponents but not on left of ^
+	token.SYM_EXP:      EXP,
+	token.SYM_COLON:    COLON,
+	token.SYM_EQL:      LESSGREATER,
+	token.SYM_LSS:      LESSGREATER,
+	token.SYM_GTR:      LESSGREATER,
+	token.SYM_NEQ:      LESSGREATER,
+	token.SYM_LEQ:      LESSGREATER,
+	token.SYM_GEQ:      LESSGREATER,
+	token.SYM_LPAREN:   CALL,
 }
 
 // rightBindingPower: how strongly an operator binds to its right operand
@@ -127,7 +127,7 @@ func New(l *lexer.Lexer) *StmtParser {
 	p.infixParseFns = make(map[string]infixParseFn)
 	p.registerInfix(token.SYM_COLON, p.parseRangeLiteral)
 
-	p.registerInfix(token.SYM_LOGICAL_OR, p.parseInfixExpression)
+	p.registerInfix(token.SYM_COND_OR, p.parseInfixExpression)
 	p.registerInfix(token.SYM_OR, p.parseInfixExpression)
 	p.registerInfix(token.SYM_XOR, p.parseInfixExpression)
 	p.registerInfix(token.SYM_AND, p.parseInfixExpression)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -791,7 +791,7 @@ func (p *StmtParser) isCondition(exp ast.Expression) bool {
 		return true
 	}
 
-	if infix, ok := exp.(*ast.InfixExpression); ok && infix.Operator == token.SYM_LOGICAL_OR {
+	if infix, ok := ast.IsLogicalOr(exp); ok {
 		return p.isCondition(infix.Left) && p.isCondition(infix.Right)
 	}
 

--- a/parser/scriptparser_test.go
+++ b/parser/scriptparser_test.go
@@ -810,6 +810,51 @@ func TestNestedGuardCondition(t *testing.T) {
 	})
 }
 
+func TestLogicalOrCondition(t *testing.T) {
+	const input = "res = a > 3 || b < 5 value"
+	l := lexer.New("TestLogicalOrCondition", input)
+	sp := NewScriptParser(l)
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Len(t, stmt.Condition, 1, "expected one condition")
+	cond, ok := stmt.Condition[0].(*ast.InfixExpression)
+	require.Truef(t, ok, "expected *ast.InfixExpression, got %T", stmt.Condition[0])
+	require.Equal(t, "||", cond.Operator)
+	require.Truef(t, testInfixExpression(t, cond.Left, "a", ">", 3), "left condition mismatch")
+	require.Truef(t, testInfixExpression(t, cond.Right, "b", "<", 5), "right condition mismatch")
+
+	require.Len(t, stmt.Value, 1, "expected one value")
+	require.True(t, testIdentifier(t, stmt.Value[0], "value"))
+}
+
+func TestLogicalOrValueExpression(t *testing.T) {
+	const input = "res = a > 3 || b < 5"
+	l := lexer.New("TestLogicalOrValueExpression", input)
+	sp := NewScriptParser(l)
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Empty(t, stmt.Condition)
+	require.Len(t, stmt.Value, 1, "expected one value")
+	require.Equal(t, "((a > 3) || (b < 5))", stmt.Value[0].String())
+}
+
+func TestLogicalOrDoesNotConsumeBitwiseOr(t *testing.T) {
+	const input = "res = 6 | 3"
+	l := lexer.New("TestLogicalOrDoesNotConsumeBitwiseOr", input)
+	sp := NewScriptParser(l)
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Empty(t, stmt.Condition)
+	require.Len(t, stmt.Value, 1, "expected one value")
+	require.Truef(t, testInfixExpression(t, stmt.Value[0], 6, "|", 3), "bitwise OR value mismatch")
+}
+
 // Function call in condition
 func TestFunctionCallInCondition(t *testing.T) {
 	const input = "res = pow(2, 3) > 8 result"

--- a/parser/scriptparser_test.go
+++ b/parser/scriptparser_test.go
@@ -829,6 +829,29 @@ func TestLogicalOrCondition(t *testing.T) {
 	require.True(t, testIdentifier(t, stmt.Value[0], "value"))
 }
 
+func TestLogicalOrConditionValueBoundary(t *testing.T) {
+	const input = "res = a > 5 || b > 6 c > 0 || d"
+	l := lexer.New("TestLogicalOrConditionValueBoundary", input)
+	sp := NewScriptParser(l)
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Len(t, stmt.Condition, 1, "expected one condition")
+	cond, ok := stmt.Condition[0].(*ast.InfixExpression)
+	require.Truef(t, ok, "expected *ast.InfixExpression, got %T", stmt.Condition[0])
+	require.Equal(t, "||", cond.Operator)
+	require.Truef(t, testInfixExpression(t, cond.Left, "a", ">", 5), "left condition mismatch")
+	require.Truef(t, testInfixExpression(t, cond.Right, "b", ">", 6), "right condition mismatch")
+
+	require.Len(t, stmt.Value, 1, "expected one value")
+	value, ok := stmt.Value[0].(*ast.InfixExpression)
+	require.Truef(t, ok, "expected *ast.InfixExpression, got %T", stmt.Value[0])
+	require.Equal(t, "||", value.Operator)
+	require.Truef(t, testInfixExpression(t, value.Left, "c", ">", 0), "left value mismatch")
+	require.Truef(t, testIdentifier(t, value.Right, "d"), "right value mismatch")
+}
+
 func TestLogicalOrValueExpression(t *testing.T) {
 	const input = "res = a > 3 || b < 5"
 	l := lexer.New("TestLogicalOrValueExpression", input)

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -76,3 +76,5 @@ LogicalOrConditionGate: [3 4 2 3 4 5]
 LogicalOrBaseFalse: 55
 LogicalOrStmtCond: 99
 LogicalOrStmtCondFalse: 77
+LogicalOrStmtShortCircuit: 99
+LogicalOrStmtShortCircuitFalse: 77

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -66,6 +66,9 @@ LogicalOrBeforeExisting: 44
 LogicalOrExistingFalse: 44
 LogicalOrNestedAdd: 8
 LogicalOrCallArg: 14
+LogicalOrHeapFallback: fallback
+LogicalOrPairFallback: 7 8
+LogicalOrNestedSum: 10
 LogicalOrDefault: -1
 LogicalOrDefaultArg: -2
 LogicalOrArrayDefault: [-1 -1 -1 3 4 5 6 7 -1 -1]

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -59,3 +59,17 @@ RangeStrMixed: s3
 RangeStrMixedBranches: s3
 re:RangeStrFalse:\s*
 NonValueCmp: 1
+LogicalOrLeft: 5
+LogicalOrRight: 7
+LogicalOrFalse: 0
+LogicalOrBeforeExisting: 44
+LogicalOrExistingFalse: 44
+LogicalOrNestedAdd: 8
+LogicalOrCallArg: 14
+LogicalOrDefault: -1
+LogicalOrDefaultArg: -2
+LogicalOrArrayDefault: [-1 -1 -1 3 4 5 6 7 -1 -1]
+LogicalOrConditionGate: [3 4 2 3 4 5]
+LogicalOrBaseFalse: 55
+LogicalOrStmtCond: 99
+LogicalOrStmtCondFalse: 77

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -78,3 +78,9 @@ LogicalOrStmtCond: 99
 LogicalOrStmtCondFalse: 77
 LogicalOrStmtShortCircuit: 99
 LogicalOrStmtShortCircuitFalse: 77
+LogicalOrBoundaryLeftBefore: 100
+LogicalOrBoundaryLeftCond: 33
+LogicalOrBoundaryRightBefore: 100
+LogicalOrBoundaryRightCondFallback: -1
+LogicalOrBoundarySkipBefore: 100
+LogicalOrBoundarySkipKeepsDefault: 100

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -248,3 +248,52 @@ rg2 = MkStr(1:4) > "z"
 ga = 1
 gb = Id(ga > 0)
 "NonValueCmp: -gb"
+
+# Logical OR in value position picks the first true conditional value.
+lorLeft = a > 2 || d < 10
+"LogicalOrLeft: -lorLeft"
+
+lorRight = b > 2 || d < 10
+"LogicalOrRight: -lorRight"
+
+lorFalse = b > 2 || d > 10
+"LogicalOrFalse: -lorFalse"
+
+lorExisting = 44
+"LogicalOrBeforeExisting: -lorExisting"
+lorExisting = b > 2 || d > 10
+"LogicalOrExistingFalse: -lorExisting"
+
+lorNestedAdd = (b > 2 || d < 10) + 1
+"LogicalOrNestedAdd: -lorNestedAdd"
+
+lorCallArg = Double(b > 2 || d < 10)
+"LogicalOrCallArg: -lorCallArg"
+
+lorDefault = b > 2 || -1
+"LogicalOrDefault: -lorDefault"
+
+lorDefaultArg = Double(b > 2 || -1)
+"LogicalOrDefaultArg: -lorDefaultArg"
+
+lorIdx = 0:10
+lorDefaultArr = [lorIdx > 2 < 8 || -1]
+"LogicalOrArrayDefault: -lorDefaultArr"
+
+gi = 0:3
+gj = 0:4
+lorGate = gi > 1 || gj > 2 [gi + gj]
+"LogicalOrConditionGate: -lorGate"
+
+lorBaseFalse = 55
+lorBaseFalse = 1 > 3 b > 2 || d < 10
+"LogicalOrBaseFalse: -lorBaseFalse"
+
+# Logical OR in statement conditions composes with comma conditions.
+lorStmt = 0
+lorStmt = b > 2 || d < 10, a > 2 99
+"LogicalOrStmtCond: -lorStmt"
+
+lorStmtFalse = 77
+lorStmtFalse = b > 2 || d > 10 99
+"LogicalOrStmtCondFalse: -lorStmtFalse"

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -306,3 +306,12 @@ lorStmt = b > 2 || d < 10, a > 2 99
 lorStmtFalse = 77
 lorStmtFalse = b > 2 || d > 10 99
 "LogicalOrStmtCondFalse: -lorStmtFalse"
+
+lorOobArr = [1]
+lorShortCircuit = 0
+lorShortCircuit = 1 < 2 || lorOobArr[5] > 0 99
+"LogicalOrStmtShortCircuit: -lorShortCircuit"
+
+lorShortCircuitFalse = 77
+lorShortCircuitFalse = 1 > 2 || lorOobArr[5] > 0 99
+"LogicalOrStmtShortCircuitFalse: -lorShortCircuitFalse"

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -270,6 +270,15 @@ lorNestedAdd = (b > 2 || d < 10) + 1
 lorCallArg = Double(b > 2 || d < 10)
 "LogicalOrCallArg: -lorCallArg"
 
+lorHeapFallback = (sl ⊕ sm) > "hello x" || "fallback"
+"LogicalOrHeapFallback: -lorHeapFallback"
+
+lorPairA, lorPairB = Pair(1, 2) > Pair(5, 5) || Pair(7, 8)
+"LogicalOrPairFallback: -lorPairA -lorPairB"
+
+lorNestedSum = (b > 2 || d < 10) + (a > 10 || c > 2)
+"LogicalOrNestedSum: -lorNestedSum"
+
 lorDefault = b > 2 || -1
 "LogicalOrDefault: -lorDefault"
 

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -315,3 +315,20 @@ lorShortCircuit = 1 < 2 || lorOobArr[5] > 0 99
 lorShortCircuitFalse = 77
 lorShortCircuitFalse = 1 > 2 || lorOobArr[5] > 0 99
 "LogicalOrStmtShortCircuitFalse: -lorShortCircuitFalse"
+
+# The first || belongs to the statement condition; the second belongs to the
+# value expression.
+lorBoundaryLeft = 100
+"LogicalOrBoundaryLeftBefore: -lorBoundaryLeft"
+lorBoundaryLeft = 9 > 5 || 0 > 6 33 > 0 || -1
+"LogicalOrBoundaryLeftCond: -lorBoundaryLeft"
+
+lorBoundaryRightFallback = 100
+"LogicalOrBoundaryRightBefore: -lorBoundaryRightFallback"
+lorBoundaryRightFallback = 1 > 5 || 9 > 6 0 > 1 || -1
+"LogicalOrBoundaryRightCondFallback: -lorBoundaryRightFallback"
+
+lorBoundarySkip = 100
+"LogicalOrBoundarySkipBefore: -lorBoundarySkip"
+lorBoundarySkip = 1 > 5 || 2 > 6 33 > 0 || -1
+"LogicalOrBoundarySkipKeepsDefault: -lorBoundarySkip"

--- a/token/token.go
+++ b/token/token.go
@@ -89,11 +89,12 @@ const (
 	SYM_LEQ = "<="
 	SYM_GEQ = ">="
 
-	// bitwise symbols
-	SYM_AND   = "&"
-	SYM_OR    = "|"
-	SYM_XOR   = "⊻"
-	SYM_TILDE = "~"
+	// logical and bitwise symbols
+	SYM_LOGICAL_OR = "||"
+	SYM_AND        = "&"
+	SYM_OR         = "|"
+	SYM_XOR        = "⊻"
+	SYM_TILDE      = "~"
 
 	// array concatenation
 	SYM_CONCAT = "⊕"

--- a/token/token.go
+++ b/token/token.go
@@ -90,11 +90,11 @@ const (
 	SYM_GEQ = ">="
 
 	// logical and bitwise symbols
-	SYM_LOGICAL_OR = "||"
-	SYM_AND        = "&"
-	SYM_OR         = "|"
-	SYM_XOR        = "⊻"
-	SYM_TILDE      = "~"
+	SYM_COND_OR = "||"
+	SYM_AND     = "&"
+	SYM_OR      = "|"
+	SYM_XOR     = "⊻"
+	SYM_TILDE   = "~"
 
 	// array concatenation
 	SYM_CONCAT = "⊕"

--- a/token/token.go
+++ b/token/token.go
@@ -89,12 +89,14 @@ const (
 	SYM_LEQ = "<="
 	SYM_GEQ = ">="
 
-	// logical and bitwise symbols
+	// conditional symbols
 	SYM_COND_OR = "||"
-	SYM_AND     = "&"
-	SYM_OR      = "|"
-	SYM_XOR     = "⊻"
-	SYM_TILDE   = "~"
+
+	// bitwise symbols
+	SYM_AND   = "&"
+	SYM_OR    = "|"
+	SYM_XOR   = "⊻"
+	SYM_TILDE = "~"
 
 	// array concatenation
 	SYM_CONCAT = "⊕"


### PR DESCRIPTION
## Summary

- Add `||` as a logical OR operator distinct from bitwise `|`.
- Support `||` in statement conditions with scalar `I1` OR lowering.
- Support value-position `||` as left-biased conditional fallback, including plain fallback values such as `a < 5 || 10`.

## Validation

- `python3 test.py tests`
