### PR TITLE
feat(language): add parenthesized conditional value (cond value)

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -481,6 +481,27 @@ func (ie *InfixExpression) String() string {
 	return out.String()
 }
 
+// CondValueExpr is a parenthesized conditional value: (cond value).
+// It yields Value when Cond holds, otherwise nothing (which a boundary
+// resolves to the zero value, or a trailing `|| fallback` overrides).
+type CondValueExpr struct {
+	Token token.Token // the '(' token
+	Cond  Expression
+	Value Expression
+}
+
+func (cv *CondValueExpr) expressionNode()  {}
+func (cv *CondValueExpr) Tok() token.Token { return cv.Token }
+func (cv *CondValueExpr) String() string {
+	var out bytes.Buffer
+	out.WriteString("(")
+	out.WriteString(cv.Cond.String())
+	out.WriteString(" ")
+	out.WriteString(cv.Value.String())
+	out.WriteString(")")
+	return out.String()
+}
+
 type FuncStatement struct {
 	Token      token.Token // The identifier
 	Parameters []*Identifier
@@ -538,6 +559,8 @@ func ExprChildren(expr Expression) []Expression {
 	switch e := expr.(type) {
 	case *InfixExpression:
 		return []Expression{e.Left, e.Right}
+	case *CondValueExpr:
+		return []Expression{e.Cond, e.Value}
 	case *PrefixExpression:
 		return []Expression{e.Right}
 	case *CallExpression:
@@ -580,6 +603,17 @@ func RewriteExpr(expr Expression, rewrite func(Expression) Expression) Expressio
 			Left:     left,
 			Operator: e.Operator,
 			Right:    right,
+		}
+	case *CondValueExpr:
+		cond := rewrite(e.Cond)
+		value := rewrite(e.Value)
+		if cond == e.Cond && value == e.Value {
+			return expr
+		}
+		return &CondValueExpr{
+			Token: e.Token,
+			Cond:  cond,
+			Value: value,
 		}
 	case *PrefixExpression:
 		right := rewrite(e.Right)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1330,6 +1330,8 @@ func (c *Compiler) compileExpression(expr ast.Expression, dest []*ast.Identifier
 		res = []*Symbol{c.compileIdentifier(e)}
 	case *ast.InfixExpression:
 		res = c.compileInfixExpression(e, dest)
+	case *ast.CondValueExpr:
+		res = c.compileCondValueExpr(e)
 	case *ast.PrefixExpression:
 		res = c.compilePrefixExpression(e, dest)
 	case *ast.CallExpression:

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -429,6 +429,12 @@ func (c *Compiler) hasFallbackOrInTree(expr ast.Expression) bool {
 	if _, ok := c.fallbackOrExpr(expr); ok {
 		return true
 	}
+	// A collector cell's || fallback is resolved at the cell level, not as a
+	// statement-level fallback (see extractCondExprs). Stop at the array
+	// boundary so the whole literal is not routed through compileYield.
+	if _, ok := expr.(*ast.ArrayLiteral); ok {
+		return false
+	}
 	for _, child := range ast.ExprChildren(expr) {
 		if c.hasFallbackOrInTree(child) {
 			return true
@@ -466,6 +472,17 @@ func (c *Compiler) handleComparisons(op string, left, right []*Symbol, info *Exp
 // values for substitution during later value compilation.
 func (c *Compiler) extractCondExprs(expr ast.Expression, cond llvm.Value, temps []condTemp) (llvm.Value, []condTemp) {
 	info := c.ExprCache[key(c.FuncNameMangled, expr)]
+
+	// An array-literal cell is an independent value position: each cell resolves
+	// its own conditional (zero-fill, or a || fallback) at the cell level via
+	// compileArrayLiteralCell. The collector is therefore a boundary for
+	// statement-level extraction — descending into it would lift a cell's
+	// value-position comparison into a gate over the whole assignment, which both
+	// keeps the old value on a single failed cell and double-evaluates that cell,
+	// leaking its heap LHS on the pass-through path.
+	if _, ok := expr.(*ast.ArrayLiteral); ok {
+		return cond, temps
+	}
 
 	// Comparisons with ranges can be extracted only when all required iterators
 	// are already bound by an outer loop (no pending ranges).

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -589,6 +589,20 @@ func (c *Compiler) compileYield(expr ast.Expression, baseCond llvm.Value, onTrue
 		return
 	}
 
+	// A (cond value) yields its value only when its condition holds; otherwise it
+	// fails to onFalse (so an enclosing || tries the next alternative).
+	if cv, ok := expr.(*ast.CondValueExpr); ok {
+		cond := c.derefIfPointer(c.compileExpression(cv.Cond, nil)[0], "cv_cond").Val
+		if !baseCond.IsNil() {
+			cond = c.builder.CreateAnd(baseCond, cond, "cv_and")
+		}
+		c.branchCond(cond, nil, func() {
+			vals := c.compileExpression(cv.Value, nil)
+			c.withCondLHS(cv, vals, onTrue)
+		}, onFalse)
+		return
+	}
+
 	if !c.hasFallbackOrInTree(expr) {
 		cond, temps := c.extractCondExprs(expr, baseCond, nil)
 		c.branchCond(cond, temps, onTrue, onFalse)
@@ -615,6 +629,41 @@ func (c *Compiler) withCondLHS(expr ast.Expression, syms []*Symbol, body func())
 	frame[exprKey] = syms
 	defer delete(frame, exprKey)
 	body()
+}
+
+// compileCondValueExpr lowers a parenthesized conditional value (cond value) by
+// local resolution: it yields Value when Cond holds, otherwise the zero value of
+// the result type. Only the taken arm is evaluated, so a heap value or fallback
+// is never allocated on the path it isn't used. When a surrounding gate (a
+// value-position ||, via compileYield) has already branched on Cond and bound
+// the chosen value under this node's key, that pre-bound value is returned.
+func (c *Compiler) compileCondValueExpr(expr *ast.CondValueExpr) []*Symbol {
+	if frame := c.currentCondLHSFrame(); frame != nil {
+		if syms, ok := frame[key(c.FuncNameMangled, expr)]; ok {
+			return syms
+		}
+	}
+
+	info := c.ExprCache[key(c.FuncNameMangled, expr)]
+	outType := info.OutTypes[0]
+
+	cond := c.derefIfPointer(c.compileExpression(expr.Cond, nil)[0], "cv_cond").Val
+	trueBlock, falseBlock, contBlock := c.createIfElseCont(cond, "cv_true", "cv_false", "cv_cont")
+
+	c.builder.SetInsertPointAtEnd(trueBlock)
+	val := c.derefIfPointer(c.compileExpression(expr.Value, nil)[0], "cv_val")
+	c.builder.CreateBr(contBlock)
+	trueEnd := c.builder.GetInsertBlock()
+
+	c.builder.SetInsertPointAtEnd(falseBlock)
+	zero := c.makeZeroValue(outType)
+	c.builder.CreateBr(contBlock)
+	falseEnd := c.builder.GetInsertBlock()
+
+	c.builder.SetInsertPointAtEnd(contBlock)
+	phi := c.builder.CreatePHI(c.mapToLLVMType(outType), "cv_phi")
+	phi.AddIncoming([]llvm.Value{val.Val, zero.Val}, []llvm.BasicBlock{trueEnd, falseEnd})
+	return []*Symbol{{Val: phi, Type: outType}}
 }
 
 func (c *Compiler) compileFallbackOr(expr *ast.InfixExpression, baseCond llvm.Value, onTrue func(), onFalse func()) {

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -14,25 +14,66 @@ type condTemp struct {
 	syms []*Symbol
 }
 
-// evalConditions compiles a list of condition expressions, ANDs all resulting
-// i1 values together, and incorporates bounds guard checks. The caller must
-// call pushBoundsGuard before and popBoundsGuard after.
+// compileGate lowers a value-position condition expression to its i1 gate: the
+// conjunction of the comparisons it contains. A condition is just a value-position
+// expression we ask "did it yield?" of — comparisons yield their LHS and chain, so
+// `i > 2 < 8` gates on `i > 2 AND i < 8`. The retained LHS values drive the gate
+// but are not a result, so they are freed here (a heap LHS computed only to test a
+// gate must not leak). Returns a nil value when expr contributes no comparison
+// (e.g. a bare range driver, whose admitted domain is handled by the loop).
+func (c *Compiler) compileGate(expr ast.Expression) llvm.Value {
+	// No || in the tree: the gate is the conjunction of the comparisons, which
+	// extractCondExprs computes directly while freeing the retained LHS temps
+	// (a heap LHS tested only for the gate must not leak).
+	if !c.hasFallbackOrInTree(expr) {
+		c.pushCondLHSFrame()
+		defer c.popCondLHSFrame()
+		cond, temps := c.extractCondExprs(expr, llvm.Value{}, nil)
+		c.cleanupCondExprElse(temps)
+		return cond
+	}
+
+	// A value-position || is a left-biased fallback, so its gate is "did the
+	// expression yield?" — a > 2 || b > 3 gates on a>2 OR b>3, not AND. Reuse the
+	// value lowering: record the gate on the yield path and free the yielded value
+	// (a gate discards it; freeTemporary skips borrowed operands, so variables are
+	// safe and heap temporaries are released).
+	i1 := Int{Width: 1}
+	i1Ty := c.mapToLLVMType(i1)
+	gatePtr := c.createEntryBlockAlloca(i1Ty, "gate.mem")
+	c.createStore(llvm.ConstInt(i1Ty, 0, false), gatePtr, i1)
+	c.compileCondExprValue(expr, llvm.Value{}, func() {
+		vals := c.compileExpression(expr, nil)
+		c.freeTemporary(expr, vals)
+		c.createStore(llvm.ConstInt(i1Ty, 1, false), gatePtr, i1)
+	})
+	return c.createLoad(gatePtr, i1, "gate")
+}
+
+// evalConditions ANDs the i1 gates of a list of condition expressions and folds
+// in the bounds-guard check. The caller must pushBoundsGuard before and
+// popBoundsGuard after.
 func (c *Compiler) evalConditions(exprs []ast.Expression, guardPtr llvm.Value) llvm.Value {
 	var cond llvm.Value
 	for _, expr := range exprs {
-		condSyms := c.compileExpression(expr, nil)
-		for _, condSym := range condSyms {
-			if cond.IsNil() {
-				cond = condSym.Val
-			} else {
-				cond = c.builder.CreateAnd(cond, condSym.Val, "and_cond")
-			}
+		gate := c.compileGate(expr)
+		if gate.IsNil() {
+			continue
+		}
+		if cond.IsNil() {
+			cond = gate
+		} else {
+			cond = c.builder.CreateAnd(cond, gate, "and_cond")
 		}
 	}
 
 	if c.stmtBoundsUsed() {
 		boundsOK := c.createLoad(guardPtr, Int{Width: 1}, "cond_bounds_ok")
-		cond = c.builder.CreateAnd(cond, boundsOK, "and_cond_bounds")
+		if cond.IsNil() {
+			cond = boundsOK
+		} else {
+			cond = c.builder.CreateAnd(cond, boundsOK, "and_cond_bounds")
+		}
 	}
 	return cond
 }
@@ -429,10 +470,11 @@ func (c *Compiler) hasFallbackOrInTree(expr ast.Expression) bool {
 	if _, ok := c.fallbackOrExpr(expr); ok {
 		return true
 	}
-	// A collector cell's || fallback is resolved at the cell level, not as a
-	// statement-level fallback (see extractCondExprs). Stop at the array
-	// boundary so the whole literal is not routed through compileYield.
-	if _, ok := expr.(*ast.ArrayLiteral); ok {
+	// Array cells and (cond value) nodes resolve any || at their own level (see
+	// extractCondExprs), so they are boundaries for statement-level fallback
+	// detection — don't descend into them.
+	switch expr.(type) {
+	case *ast.ArrayLiteral, *ast.CondValueExpr:
 		return false
 	}
 	for _, child := range ast.ExprChildren(expr) {
@@ -473,14 +515,14 @@ func (c *Compiler) handleComparisons(op string, left, right []*Symbol, info *Exp
 func (c *Compiler) extractCondExprs(expr ast.Expression, cond llvm.Value, temps []condTemp) (llvm.Value, []condTemp) {
 	info := c.ExprCache[key(c.FuncNameMangled, expr)]
 
-	// An array-literal cell is an independent value position: each cell resolves
-	// its own conditional (zero-fill, or a || fallback) at the cell level via
-	// compileArrayLiteralCell. The collector is therefore a boundary for
-	// statement-level extraction — descending into it would lift a cell's
-	// value-position comparison into a gate over the whole assignment, which both
-	// keeps the old value on a single failed cell and double-evaluates that cell,
-	// leaking its heap LHS on the pass-through path.
-	if _, ok := expr.(*ast.ArrayLiteral); ok {
+	// Array-literal cells and (cond value) nodes are local-resolution boundaries:
+	// each resolves its own condition (zero-fill / fallback, or the cond-value's
+	// branch) at its own level. Statement-level extraction must stop here —
+	// descending in would lift their inner comparison into a gate over the whole
+	// assignment, which keeps the old value on failure (breaking local resolution)
+	// and double-evaluates the node, leaking its heap LHS on the pass-through path.
+	switch expr.(type) {
+	case *ast.ArrayLiteral, *ast.CondValueExpr:
 		return cond, temps
 	}
 
@@ -609,7 +651,7 @@ func (c *Compiler) compileYield(expr ast.Expression, baseCond llvm.Value, onTrue
 	// A (cond value) yields its value only when its condition holds; otherwise it
 	// fails to onFalse (so an enclosing || tries the next alternative).
 	if cv, ok := expr.(*ast.CondValueExpr); ok {
-		cond := c.derefIfPointer(c.compileExpression(cv.Cond, nil)[0], "cv_cond").Val
+		cond := c.compileGate(cv.Cond)
 		if !baseCond.IsNil() {
 			cond = c.builder.CreateAnd(baseCond, cond, "cv_and")
 		}
@@ -678,7 +720,7 @@ func (c *Compiler) compileCondValueExpr(expr *ast.CondValueExpr) []*Symbol {
 func (c *Compiler) compileCondValueExprBasic(expr *ast.CondValueExpr, info *ExprInfo) []*Symbol {
 	outTypes := info.OutTypes
 
-	cond := c.derefIfPointer(c.compileExpression(expr.Cond, nil)[0], "cv_cond").Val
+	cond := c.compileGate(expr.Cond)
 	trueBlock, falseBlock, contBlock := c.createIfElseCont(cond, "cv_true", "cv_false", "cv_cont")
 
 	// True path evaluates the value (one symbol per output slot for a

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -645,25 +645,37 @@ func (c *Compiler) compileCondValueExpr(expr *ast.CondValueExpr) []*Symbol {
 	}
 
 	info := c.ExprCache[key(c.FuncNameMangled, expr)]
-	outType := info.OutTypes[0]
+	outTypes := info.OutTypes
 
 	cond := c.derefIfPointer(c.compileExpression(expr.Cond, nil)[0], "cv_cond").Val
 	trueBlock, falseBlock, contBlock := c.createIfElseCont(cond, "cv_true", "cv_false", "cv_cont")
 
+	// True path evaluates the value (one symbol per output slot for a
+	// multi-return value); false path yields the zero of each slot's type.
 	c.builder.SetInsertPointAtEnd(trueBlock)
-	val := c.derefIfPointer(c.compileExpression(expr.Value, nil)[0], "cv_val")
+	vals := c.compileExpression(expr.Value, nil)
+	for i := range vals {
+		vals[i] = c.derefIfPointer(vals[i], "cv_val")
+	}
 	c.builder.CreateBr(contBlock)
 	trueEnd := c.builder.GetInsertBlock()
 
 	c.builder.SetInsertPointAtEnd(falseBlock)
-	zero := c.makeZeroValue(outType)
+	zeros := make([]*Symbol, len(outTypes))
+	for i, t := range outTypes {
+		zeros[i] = c.makeZeroValue(t)
+	}
 	c.builder.CreateBr(contBlock)
 	falseEnd := c.builder.GetInsertBlock()
 
 	c.builder.SetInsertPointAtEnd(contBlock)
-	phi := c.builder.CreatePHI(c.mapToLLVMType(outType), "cv_phi")
-	phi.AddIncoming([]llvm.Value{val.Val, zero.Val}, []llvm.BasicBlock{trueEnd, falseEnd})
-	return []*Symbol{{Val: phi, Type: outType}}
+	res := make([]*Symbol, len(outTypes))
+	for i, t := range outTypes {
+		phi := c.builder.CreatePHI(c.mapToLLVMType(t), "cv_phi")
+		phi.AddIncoming([]llvm.Value{vals[i].Val, zeros[i].Val}, []llvm.BasicBlock{trueEnd, falseEnd})
+		res[i] = &Symbol{Val: phi, Type: t}
+	}
+	return res
 }
 
 func (c *Compiler) compileFallbackOr(expr *ast.InfixExpression, baseCond llvm.Value, onTrue func(), onFalse func()) {

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -54,15 +54,13 @@ func (c *Compiler) compileGate(expr ast.Expression) llvm.Value {
 // in the bounds-guard check. The caller must pushBoundsGuard before and
 // popBoundsGuard after.
 func (c *Compiler) evalConditions(exprs []ast.Expression, guardPtr llvm.Value) llvm.Value {
+	// Every condition reaching evalConditions is a comparison: validation rejects
+	// non-comparison gates, and splitCondRanges routes bare range drivers into the
+	// range list rather than here. So compileGate returns a non-nil gate for each,
+	// and since callers pass a non-empty list, cond is non-nil after the loop.
 	var cond llvm.Value
 	for _, expr := range exprs {
-		// compileGate returns nil for a condition that contributes no comparison
-		// (e.g. a bare range driver) — it adds no constraint, so skip it. Unlike the
-		// old per-condition i1, this means the loop can accumulate zero gates.
 		gate := c.compileGate(expr)
-		if gate.IsNil() {
-			continue
-		}
 		if cond.IsNil() {
 			cond = gate
 		} else {
@@ -72,14 +70,7 @@ func (c *Compiler) evalConditions(exprs []ast.Expression, guardPtr llvm.Value) l
 
 	if c.stmtBoundsUsed() {
 		boundsOK := c.createLoad(guardPtr, Int{Width: 1}, "cond_bounds_ok")
-		// If no condition produced a gate (all skipped above), cond is nil and the
-		// bounds check is the whole gate; otherwise AND it in. (Guards against
-		// CreateAnd on a nil cond — only reachable if compileGate yields nil here.)
-		if cond.IsNil() {
-			cond = boundsOK
-		} else {
-			cond = c.builder.CreateAnd(cond, boundsOK, "and_cond_bounds")
-		}
+		cond = c.builder.CreateAnd(cond, boundsOK, "and_cond_bounds")
 	}
 	return cond
 }

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -711,8 +711,23 @@ func (c *Compiler) compileCondValueExprRanges(expr *ast.CondValueExpr, info *Exp
 		defer c.popBoundsGuard()
 
 		vals := c.compileCondValueExprBasic(prepared)
-		for i := range vals {
-			c.storeSymbolToSlot(outputs[i], vals[i], info.OutTypes[i], "cv_iter_store")
+
+		// Free the previous iteration's value before overwriting, and route the
+		// store through the active bounds guard so out-of-bounds iterations skip
+		// it (keeping the last in-bounds value) — matching the other range paths.
+		store := func() {
+			for i := range vals {
+				c.freeSymbolValue(outputs[i], "cv_old_output")
+				c.storeSymbolToSlot(outputs[i], vals[i], info.OutTypes[i], "cv_iter_store")
+			}
+		}
+		skip := func() {
+			for i := range vals {
+				c.freeTemporarySymbol(vals[i], "cv_skip_drop")
+			}
+		}
+		if !c.withStmtBoundsGuard("cv_bounds_ok", "cv_bounds_run", "cv_bounds_skip", "cv_bounds_cont", store, skip) {
+			store()
 		}
 	})
 

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -547,8 +547,16 @@ func (c *Compiler) extractCondComparison(infix *ast.InfixExpression, info *ExprI
 	var lhsSyms []*Symbol
 	lhsSyms, cond = c.handleComparisons(infix.Operator, left, right, info, cond)
 
-	c.requireCondLHSFrame()[key(c.FuncNameMangled, infix)] = lhsSyms
-	temps = append(temps, condTemp{infix.Left, left})
+	frame := c.requireCondLHSFrame()
+	frame[key(c.FuncNameMangled, infix)] = lhsSyms
+
+	// Track `left` as a temporary to free in cleanup — but not when it is a chained
+	// inner comparison (a > b < c): its value came from substituting that already-
+	// retained comparison, so it is the SAME symbol already tracked. Re-tracking it
+	// would free it twice (double-free / crash) for a heap LHS.
+	if _, chained := frame[key(c.FuncNameMangled, infix.Left)]; !chained {
+		temps = append(temps, condTemp{infix.Left, left})
+	}
 
 	// Right is comparison-only; left is retained for condLHS substitution.
 	c.freeTemporary(infix.Right, right)

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -631,12 +631,12 @@ func (c *Compiler) withCondLHS(expr ast.Expression, syms []*Symbol, body func())
 	body()
 }
 
-// compileCondValueExpr lowers a parenthesized conditional value (cond value) by
-// local resolution: it yields Value when Cond holds, otherwise the zero value of
-// the result type. Only the taken arm is evaluated, so a heap value or fallback
-// is never allocated on the path it isn't used. When a surrounding gate (a
-// value-position ||, via compileYield) has already branched on Cond and bound
-// the chosen value under this node's key, that pre-bound value is returned.
+// compileCondValueExpr lowers a parenthesized conditional value (cond value).
+// When a surrounding gate (a value-position ||, via compileYield) has already
+// branched on Cond and bound the chosen value under this node's key, that
+// pre-bound value is returned. With pending ranges (e.g. the root `r = (i>2 i)`)
+// it drives a loop; otherwise it compiles the scalar branch/phi, using the
+// range-scalarized rewrite when an outer loop already bound the iterators.
 func (c *Compiler) compileCondValueExpr(expr *ast.CondValueExpr) []*Symbol {
 	if frame := c.currentCondLHSFrame(); frame != nil {
 		if syms, ok := frame[key(c.FuncNameMangled, expr)]; ok {
@@ -644,6 +644,20 @@ func (c *Compiler) compileCondValueExpr(expr *ast.CondValueExpr) []*Symbol {
 		}
 	}
 
+	info := c.ExprCache[key(c.FuncNameMangled, expr)]
+	if len(c.pendingLoopRanges(info.Ranges)) > 0 {
+		return c.compileCondValueExprRanges(expr, info)
+	}
+	if rew, ok := info.Rewrite.(*ast.CondValueExpr); ok && rew != expr {
+		expr = rew
+	}
+	return c.compileCondValueExprBasic(expr)
+}
+
+// compileCondValueExprBasic is the scalar lowering: yield Value when Cond holds,
+// otherwise the zero of each output slot's type. Only the taken arm is
+// evaluated, so a heap value is never allocated on the path it isn't used.
+func (c *Compiler) compileCondValueExprBasic(expr *ast.CondValueExpr) []*Symbol {
 	info := c.ExprCache[key(c.FuncNameMangled, expr)]
 	outTypes := info.OutTypes
 
@@ -676,6 +690,38 @@ func (c *Compiler) compileCondValueExpr(expr *ast.CondValueExpr) []*Symbol {
 		res[i] = &Symbol{Val: phi, Type: t}
 	}
 	return res
+}
+
+// compileCondValueExprRanges lowers a range-bearing (cond value) at the root of
+// an assignment: it loops the iteration domain, writing the per-iteration
+// value-or-zero into a seeded output slot, and the final iteration's value wins
+// (root assignment keeps the last yielded value).
+func (c *Compiler) compileCondValueExprRanges(expr *ast.CondValueExpr, info *ExprInfo) []*Symbol {
+	PushScope(&c.Scopes, BlockScope)
+	defer c.popScope()
+
+	outputs := c.makeOutputs(nil, info.OutTypes, true)
+	for i, t := range info.OutTypes {
+		c.storeSymbolToSlot(outputs[i], c.makeZeroValue(t), t, "cv_seed")
+	}
+
+	rew := info.Rewrite.(*ast.CondValueExpr)
+	withCollectorPreparedLoopNest(c, rew, info.Ranges, nil, nil, func(prepared *ast.CondValueExpr) {
+		c.pushBoundsGuard("condval_iter_bounds_guard")
+		defer c.popBoundsGuard()
+
+		vals := c.compileCondValueExprBasic(prepared)
+		for i := range vals {
+			c.storeSymbolToSlot(outputs[i], vals[i], info.OutTypes[i], "cv_iter_store")
+		}
+	})
+
+	out := make([]*Symbol, len(outputs))
+	for i := range outputs {
+		elemType := outputs[i].Type.(Ptr).Elem
+		out[i] = &Symbol{Val: c.createLoad(outputs[i].Val, elemType, "cv_final"), Type: elemType}
+	}
+	return out
 }
 
 func (c *Compiler) compileFallbackOr(expr *ast.InfixExpression, baseCond llvm.Value, onTrue func(), onFalse func()) {

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -650,15 +650,15 @@ func (c *Compiler) compileCondValueExpr(expr *ast.CondValueExpr) []*Symbol {
 	}
 	if rew, ok := info.Rewrite.(*ast.CondValueExpr); ok && rew != expr {
 		expr = rew
+		info = c.ExprCache[key(c.FuncNameMangled, expr)]
 	}
-	return c.compileCondValueExprBasic(expr)
+	return c.compileCondValueExprBasic(expr, info)
 }
 
 // compileCondValueExprBasic is the scalar lowering: yield Value when Cond holds,
 // otherwise the zero of each output slot's type. Only the taken arm is
 // evaluated, so a heap value is never allocated on the path it isn't used.
-func (c *Compiler) compileCondValueExprBasic(expr *ast.CondValueExpr) []*Symbol {
-	info := c.ExprCache[key(c.FuncNameMangled, expr)]
+func (c *Compiler) compileCondValueExprBasic(expr *ast.CondValueExpr, info *ExprInfo) []*Symbol {
 	outTypes := info.OutTypes
 
 	cond := c.derefIfPointer(c.compileExpression(expr.Cond, nil)[0], "cv_cond").Val
@@ -710,7 +710,7 @@ func (c *Compiler) compileCondValueExprRanges(expr *ast.CondValueExpr, info *Exp
 		c.pushBoundsGuard("condval_iter_bounds_guard")
 		defer c.popBoundsGuard()
 
-		vals := c.compileCondValueExprBasic(prepared)
+		vals := c.compileCondValueExprBasic(prepared, c.ExprCache[key(c.FuncNameMangled, prepared)])
 
 		// Free the previous iteration's value before overwriting, and route the
 		// store through the active bounds guard so out-of-bounds iterations skip

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -56,6 +56,9 @@ func (c *Compiler) compileGate(expr ast.Expression) llvm.Value {
 func (c *Compiler) evalConditions(exprs []ast.Expression, guardPtr llvm.Value) llvm.Value {
 	var cond llvm.Value
 	for _, expr := range exprs {
+		// compileGate returns nil for a condition that contributes no comparison
+		// (e.g. a bare range driver) — it adds no constraint, so skip it. Unlike the
+		// old per-condition i1, this means the loop can accumulate zero gates.
 		gate := c.compileGate(expr)
 		if gate.IsNil() {
 			continue
@@ -69,6 +72,9 @@ func (c *Compiler) evalConditions(exprs []ast.Expression, guardPtr llvm.Value) l
 
 	if c.stmtBoundsUsed() {
 		boundsOK := c.createLoad(guardPtr, Int{Width: 1}, "cond_bounds_ok")
+		// If no condition produced a gate (all skipped above), cond is nil and the
+		// bounds check is the whole gate; otherwise AND it in. (Guards against
+		// CreateAnd on a nil cond — only reachable if compileGate yields nil here.)
 		if cond.IsNil() {
 			cond = boundsOK
 		} else {

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -748,6 +748,19 @@ func (ts *TypeSolver) collectDriverRanges(expr ast.Expression, condTypes []Type)
 	return []*RangeInfo{{Name: ident.Value}}
 }
 
+// conditionCanFail reports whether a value-position condition can fail (skip) —
+// which a statement gate requires, since an always-yielding condition can never
+// gate. A comparison or chain can fail; a value-position || can only if its final
+// fallback can: `a > 0 || b > 0` fails when both are false, but `a > 0 || b`
+// always yields b.
+func (ts *TypeSolver) conditionCanFail(expr ast.Expression) bool {
+	if infix, ok := ast.IsLogicalOr(expr); ok {
+		return ts.conditionCanFail(infix.Right)
+	}
+	info := ts.ExprCache[key(ts.FuncNameMangled, expr)]
+	return info != nil && info.HasCondExpr()
+}
+
 func (ts *TypeSolver) validateStatementCondition(expr ast.Expression, condTypes []Type) {
 	if len(condTypes) != 1 {
 		ts.Errors = append(ts.Errors, &token.CompileError{
@@ -774,7 +787,20 @@ func (ts *TypeSolver) validateStatementCondition(expr ast.Expression, condTypes 
 		return
 	}
 
-	if intType, ok := condType.(Int); ok && intType.Width == 1 {
+	// In value context a comparison yields its LHS (so the condition's type is the
+	// operand type, not i1); it gates as long as it can fail — the gate is the
+	// conjunction of its comparisons ("did the value-position expression yield?").
+	if ts.conditionCanFail(expr) {
+		return
+	}
+
+	// A condition that carries a comparison but can never fail (an unconditional
+	// || fallback like `a > 0 || b`, which always yields b) does not gate.
+	if info := ts.ExprCache[key(ts.FuncNameMangled, expr)]; info != nil && info.HasCondExpr() {
+		ts.Errors = append(ts.Errors, &token.CompileError{
+			Token: expr.Tok(),
+			Msg:   "statement condition can never fail (its || fallback always yields a value)",
+		})
 		return
 	}
 
@@ -842,8 +868,11 @@ func (ts *TypeSolver) TypeLetStatement(stmt *ast.LetStatement) {
 	savedInValueExpr := ts.InValueExpr
 	defer func() { ts.InValueExpr = savedInValueExpr }()
 
-	// type conditions in non-value context (comparisons produce i1 as usual)
-	ts.InValueExpr = false
+	// Type conditions in value context, like the values: a comparison yields its
+	// LHS and chains (so `i > 2 < 8` works), and the gate is the conjunction of
+	// those comparisons ("did the value-position expression yield?"). One
+	// comparison rule everywhere; the gate collapse to i1 happens at lowering.
+	ts.InValueExpr = true
 	for _, expr := range stmt.Condition {
 		condTypes := ts.TypeExpression(expr, true)
 		ts.validateStatementCondition(expr, condTypes)
@@ -1533,13 +1562,14 @@ func (ts *TypeSolver) logicalOrValueType(leftType, rightType Type, tok token.Tok
 }
 
 // typeCondValueExpr types a parenthesized conditional value (cond value).
-// The condition is typed in non-value context (a comparison yields i1, not its
-// LHS) and must be a boolean; the result type is the value's type. Slots are
-// marked CondValue so the value gates on lowering and the node can serve as the
-// (failable) left operand of a value-position ||.
+// The condition is typed in value context (like a statement gate): a comparison
+// yields its LHS and chains (so `(i > 2 < 8  v)` works), and it gates on whether
+// that value-position expression yields — so it must be able to fail. The result
+// type is the value's type. Slots are marked CondValue so the value gates on
+// lowering and the node can serve as the (failable) left operand of a value-position ||.
 func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []Type {
 	savedInValueExpr := ts.InValueExpr
-	ts.InValueExpr = false
+	ts.InValueExpr = true
 	condTypes := ts.TypeExpression(expr.Cond, true)
 	ts.InValueExpr = savedInValueExpr
 
@@ -1548,10 +1578,10 @@ func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []
 			Token: expr.Token,
 			Msg:   fmt.Sprintf("(cond value) condition must produce a single value, got %d", len(condTypes)),
 		})
-	} else if condTypes[0].Kind() != UnresolvedKind && !IsI1(condTypes[0]) {
+	} else if condTypes[0].Kind() != UnresolvedKind && !ts.conditionCanFail(expr.Cond) {
 		ts.Errors = append(ts.Errors, &token.CompileError{
 			Token: expr.Token,
-			Msg:   fmt.Sprintf("(cond value) condition must be a comparison or boolean, got %s", condTypes[0]),
+			Msg:   fmt.Sprintf("(cond value) condition must be a comparison that can fail, got %s", condTypes[0]),
 		})
 	}
 

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1579,6 +1579,37 @@ func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []
 	return types
 }
 
+// wrapsPropagatingCond reports whether expr wraps a *propagating* value-position
+// condition — a comparison (CondScalar) or a value-position || (CondOr) — anywhere
+// in its tree. Those propagate their failure to the whole value (the same gating
+// that drives zero-fill), so a fallback || can attach to a left operand that wraps
+// one in arithmetic, e.g. (i > 2 < 8) ^ 2 || -1.
+//
+// A (cond value) and an array cell resolve *locally* (they always produce a value
+// and never propagate a failure outward), so a condition nested inside one does
+// not make the wrapping operand fail — the walk stops at those boundaries. A bare
+// (cond value) at the root is handled by the caller's HasCondExpr check, since the
+// || keys off its condition directly.
+func (ts *TypeSolver) wrapsPropagatingCond(expr ast.Expression) bool {
+	if info := ts.ExprCache[key(ts.FuncNameMangled, expr)]; info != nil {
+		for _, m := range info.CompareModes {
+			if m == CondScalar || m == CondOr {
+				return true
+			}
+		}
+	}
+	switch expr.(type) {
+	case *ast.CondValueExpr, *ast.ArrayLiteral:
+		return false
+	}
+	for _, child := range ast.ExprChildren(expr) {
+		if ts.wrapsPropagatingCond(child) {
+			return true
+		}
+	}
+	return false
+}
+
 func (ts *TypeSolver) typeLogicalOrExpression(expr *ast.InfixExpression, left, right []Type) []Type {
 	leftInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Left)]
 	rightInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Right)]
@@ -1588,8 +1619,10 @@ func (ts *TypeSolver) typeLogicalOrExpression(expr *ast.InfixExpression, left, r
 		// fail, while the right operand may be another condition or a plain
 		// fallback value. There is no matching value-position && because
 		// chained comparisons already refine a yielded value, and comma
-		// conditions provide statement-position AND.
-		if leftInfo == nil || !leftInfo.HasCondExpr() {
+		// conditions provide statement-position AND. The left counts as failable
+		// if its root is conditional, or if it wraps a propagating condition in
+		// arithmetic — (i > 2 < 8) ^ 2 || -1 keys off the nested comparison.
+		if leftInfo == nil || (!leftInfo.HasCondExpr() && !ts.wrapsPropagatingCond(expr.Left)) {
 			ts.Errors = append(ts.Errors, &token.CompileError{
 				Token: expr.Token,
 				Msg:   "logical OR in value position requires a conditional left operand",

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -360,6 +360,8 @@ func (ts *TypeSolver) HandleRanges(e ast.Expression) (ranges []*RangeInfo, rew a
 		return ts.HandleArrayRangeExpression(t)
 	case *ast.InfixExpression:
 		return ts.HandleInfixRanges(t)
+	case *ast.CondValueExpr:
+		return ts.HandleCondValueRanges(t)
 	case *ast.PrefixExpression:
 		return ts.HandlePrefixRanges(t)
 	case *ast.CallExpression:
@@ -479,6 +481,34 @@ func (ts *TypeSolver) HandleArrayRangeExpression(ar *ast.ArrayRangeExpression) (
 
 // HandleInfixRanges processes infix expressions, recursively handling both operands
 // and tracking whether each side contains ranges for optimization decisions.
+func (ts *TypeSolver) HandleCondValueRanges(cv *ast.CondValueExpr) (ranges []*RangeInfo, rew ast.Expression) {
+	condRanges, cond := ts.HandleRanges(cv.Cond)
+	valRanges, val := ts.HandleRanges(cv.Value)
+	ranges = mergeUses(condRanges, valRanges)
+
+	if cond == cv.Cond && val == cv.Value {
+		rew = cv
+	} else {
+		cp := *cv
+		cp.Cond, cp.Value = cond, val
+		rew = &cp
+		// Cache entry for the rewritten node: operands are scalarized iterators.
+		originalInfo := ts.ExprCache[key(ts.FuncNameMangled, cv)]
+		ts.ExprCache[key(ts.FuncNameMangled, rew.(*ast.CondValueExpr))] = &ExprInfo{
+			OutTypes:     append([]Type(nil), originalInfo.OutTypes...),
+			ExprLen:      originalInfo.ExprLen,
+			HasRanges:    false,
+			CompareModes: append([]CondMode(nil), originalInfo.CompareModes...),
+			Ranges:       nil,
+		}
+	}
+
+	info := ts.ExprCache[key(ts.FuncNameMangled, cv)]
+	info.Ranges = ranges
+	info.Rewrite = rew
+	return
+}
+
 func (ts *TypeSolver) HandleInfixRanges(infix *ast.InfixExpression) (ranges []*RangeInfo, rew ast.Expression) {
 	lRanges, l := ts.HandleRanges(infix.Left)
 	rRanges, r := ts.HandleRanges(infix.Right)
@@ -1525,21 +1555,13 @@ func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []
 		})
 	}
 
-	valueTypes := ts.TypeExpression(expr.Value, isRoot)
+	// The value is always a nested, per-iteration value (the CondValueExpr or its
+	// enclosing context owns any loop), so type it non-root: a range identifier
+	// resolves to its iterator type, not a Range.
+	valueTypes := ts.TypeExpression(expr.Value, false)
 
 	condInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Cond)]
 	valInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Value)]
-
-	// Ranges inside a (cond value) are not yet iterated by its scalar branch/phi
-	// lowering, so reject them rather than silently produce a wrong result. A
-	// range-driven conditional collection is available via the comparison form
-	// (e.g. `[i > 2]`), which yields the left operand and zero-fills.
-	if (condInfo != nil && condInfo.HasRanges) || (valInfo != nil && valInfo.HasRanges) {
-		ts.Errors = append(ts.Errors, &token.CompileError{
-			Token: expr.Token,
-			Msg:   "(cond value) does not support ranges yet; use the comparison form (e.g. [i > 2]) for range-driven conditional values",
-		})
-	}
 
 	types := make([]Type, len(valueTypes))
 	copy(types, valueTypes)

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1568,10 +1568,14 @@ func (ts *TypeSolver) logicalOrValueType(leftType, rightType Type, tok token.Tok
 // type is the value's type. Slots are marked CondValue so the value gates on
 // lowering and the node can serve as the (failable) left operand of a value-position ||.
 func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []Type {
+	// The condition and the value are both value positions (comparisons yield their
+	// LHS and chain), so type both with InValueExpr set and restore on return. Every
+	// caller already types within a value/condition context (InValueExpr is true),
+	// so this is explicit-intent rather than strictly required.
 	savedInValueExpr := ts.InValueExpr
 	ts.InValueExpr = true
+	defer func() { ts.InValueExpr = savedInValueExpr }()
 	condTypes := ts.TypeExpression(expr.Cond, true)
-	ts.InValueExpr = savedInValueExpr
 
 	if len(condTypes) != 1 {
 		ts.Errors = append(ts.Errors, &token.CompileError{

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -103,7 +103,7 @@ type TypeSolver struct {
 	BindingTypes    map[BindingKey]Type
 	ExprCache       map[ExprKey]*ExprInfo
 	TmpCounter      int  // tmpCounter for uniquely naming temporary variables
-	InValueExpr     bool // value position (LetStatement conditions/values, (cond value)): comparisons yield their LHS and chain, || is fallback — not booleans as in function args
+	InValueExpr     bool // value position (LetStatement conditions/values, (cond value); inherited by nested exprs): comparisons yield their LHS and chain, || is fallback — vs plain booleans in non-value contexts like prints
 	UnresolvedExprs map[pendingBinding][]pendingExpr
 }
 

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1530,6 +1530,17 @@ func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []
 	condInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Cond)]
 	valInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Value)]
 
+	// Ranges inside a (cond value) are not yet iterated by its scalar branch/phi
+	// lowering, so reject them rather than silently produce a wrong result. A
+	// range-driven conditional collection is available via the comparison form
+	// (e.g. `[i > 2]`), which yields the left operand and zero-fills.
+	if (condInfo != nil && condInfo.HasRanges) || (valInfo != nil && valInfo.HasRanges) {
+		ts.Errors = append(ts.Errors, &token.CompileError{
+			Token: expr.Token,
+			Msg:   "(cond value) does not support ranges yet; use the comparison form (e.g. [i > 2]) for range-driven conditional values",
+		})
+	}
+
 	types := make([]Type, len(valueTypes))
 	copy(types, valueTypes)
 	compareModes := make([]CondMode, len(valueTypes))

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1568,11 +1568,14 @@ func (ts *TypeSolver) logicalOrValueType(leftType, rightType Type, tok token.Tok
 // type is the value's type. Slots are marked CondValue so the value gates on
 // lowering and the node can serve as the (failable) left operand of a value-position ||.
 func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []Type {
-	// The condition and value are both value positions (comparisons yield their LHS
-	// and chain). A (cond value) is only ever typed within a let condition or value,
-	// both already value context (InValueExpr true), so no flip is needed. A non-value
-	// caller would be caught loudly by the conditionCanFail check below — the cond
-	// would type as a plain boolean, not a failable comparison.
+	// A (cond value)'s condition and value are intrinsically value positions
+	// (comparisons yield their LHS and chain), independent of the surrounding
+	// statement: the cond IS a gate by construction. A print/root expression
+	// statement does not set InValueExpr, so force it here (and restore on return)
+	// rather than relying on the enclosing context.
+	savedInValueExpr := ts.InValueExpr
+	ts.InValueExpr = true
+	defer func() { ts.InValueExpr = savedInValueExpr }()
 	condTypes := ts.TypeExpression(expr.Cond, true)
 
 	if len(condTypes) != 1 {

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1654,7 +1654,7 @@ func (ts *TypeSolver) typeLogicalOrExpression(expr *ast.InfixExpression, left, r
 		// left must be able to fail or the fallback is dead. Failable: its root is
 		// conditional, or it wraps a propagating comparison in arithmetic (e.g.
 		// (i > 2 < 8) ^ 2 || -1 keys off the nested comparison).
-		if leftInfo == nil || (!leftInfo.HasCondExpr() && !ts.wrapsPropagatingCond(expr.Left)) {
+		if leftInfo == nil || !(leftInfo.HasCondExpr() || ts.wrapsPropagatingCond(expr.Left)) {
 			ts.Errors = append(ts.Errors, &token.CompileError{
 				Token: expr.Token,
 				Msg:   "logical OR in value position requires a conditional left operand",

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -103,7 +103,7 @@ type TypeSolver struct {
 	BindingTypes    map[BindingKey]Type
 	ExprCache       map[ExprKey]*ExprInfo
 	TmpCounter      int  // tmpCounter for uniquely naming temporary variables
-	InValueExpr     bool // true in value-position contexts (LetStatement conditions and values, and (cond value)): comparisons yield their LHS and chain, and || is the asymmetric fallback operator, rather than producing booleans. False in boolean contexts like function arguments.
+	InValueExpr     bool // value position (LetStatement conditions/values, (cond value)): comparisons yield their LHS and chain, || is fallback — not booleans as in function args
 	UnresolvedExprs map[pendingBinding][]pendingExpr
 }
 
@@ -1650,13 +1650,10 @@ func (ts *TypeSolver) typeLogicalOrExpression(expr *ast.InfixExpression, left, r
 	rightInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Right)]
 
 	if ts.InValueExpr {
-		// Value-position OR is asymmetric: the left operand must be able to
-		// fail, while the right operand may be another condition or a plain
-		// fallback value. There is no matching value-position && because
-		// chained comparisons already refine a yielded value, and comma
-		// conditions provide statement-position AND. The left counts as failable
-		// if its root is conditional, or if it wraps a propagating condition in
-		// arithmetic — (i > 2 < 8) ^ 2 || -1 keys off the nested comparison.
+		// Value-position || is left-biased fallback (yield left, else right), so the
+		// left must be able to fail or the fallback is dead. Failable: its root is
+		// conditional, or it wraps a propagating comparison in arithmetic (e.g.
+		// (i > 2 < 8) ^ 2 || -1 keys off the nested comparison).
 		if leftInfo == nil || (!leftInfo.HasCondExpr() && !ts.wrapsPropagatingCond(expr.Left)) {
 			ts.Errors = append(ts.Errors, &token.CompileError{
 				Token: expr.Token,

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -23,6 +23,7 @@ const (
 	CondScalar                 // Scalar: extract LHS value, branch on condition
 	CondArray                  // Array: element-wise filter, keep LHS where condition holds
 	CondOr                     // Fallback OR in value position: first true operand wins
+	CondValue                  // Parenthesized (cond value): yield value when cond holds, else zero
 )
 
 type ExprInfo struct {
@@ -59,7 +60,7 @@ func (info *ExprInfo) HasFallbackOr() bool {
 
 func (info *ExprInfo) HasCondExpr() bool {
 	for _, m := range info.CompareModes {
-		if m == CondScalar || m == CondOr {
+		if m == CondScalar || m == CondOr || m == CondValue {
 			return true
 		}
 	}
@@ -1353,6 +1354,8 @@ func (ts *TypeSolver) TypeExpression(expr ast.Expression, isRoot bool) (types []
 		types = append(types, t)
 	case *ast.InfixExpression:
 		types = ts.TypeInfixExpression(e)
+	case *ast.CondValueExpr:
+		types = ts.typeCondValueExpr(e, isRoot)
 	case *ast.PrefixExpression:
 		types = ts.TypePrefixExpression(e)
 	case *ast.CallExpression:
@@ -1497,6 +1500,50 @@ func (ts *TypeSolver) logicalOrValueType(leftType, rightType Type, tok token.Tok
 		})
 		return Unresolved{}
 	}
+}
+
+// typeCondValueExpr types a parenthesized conditional value (cond value).
+// The condition is typed in non-value context (a comparison yields i1, not its
+// LHS) and must be a boolean; the result type is the value's type. Slots are
+// marked CondValue so the value gates on lowering and the node can serve as the
+// (failable) left operand of a value-position ||.
+func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []Type {
+	savedInValueExpr := ts.InValueExpr
+	ts.InValueExpr = false
+	condTypes := ts.TypeExpression(expr.Cond, true)
+	ts.InValueExpr = savedInValueExpr
+
+	if len(condTypes) != 1 {
+		ts.Errors = append(ts.Errors, &token.CompileError{
+			Token: expr.Token,
+			Msg:   fmt.Sprintf("(cond value) condition must produce a single value, got %d", len(condTypes)),
+		})
+	} else if condTypes[0].Kind() != UnresolvedKind && !IsI1(condTypes[0]) {
+		ts.Errors = append(ts.Errors, &token.CompileError{
+			Token: expr.Token,
+			Msg:   fmt.Sprintf("(cond value) condition must be a comparison or boolean, got %s", condTypes[0]),
+		})
+	}
+
+	valueTypes := ts.TypeExpression(expr.Value, isRoot)
+
+	condInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Cond)]
+	valInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Value)]
+
+	types := make([]Type, len(valueTypes))
+	copy(types, valueTypes)
+	compareModes := make([]CondMode, len(valueTypes))
+	for i := range compareModes {
+		compareModes[i] = CondValue
+	}
+
+	ts.ExprCache[key(ts.FuncNameMangled, expr)] = &ExprInfo{
+		OutTypes:     types,
+		ExprLen:      len(types),
+		HasRanges:    (condInfo != nil && condInfo.HasRanges) || (valInfo != nil && valInfo.HasRanges),
+		CompareModes: compareModes,
+	}
+	return types
 }
 
 func (ts *TypeSolver) typeLogicalOrExpression(expr *ast.InfixExpression, left, right []Type) []Type {

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -103,7 +103,7 @@ type TypeSolver struct {
 	BindingTypes    map[BindingKey]Type
 	ExprCache       map[ExprKey]*ExprInfo
 	TmpCounter      int  // tmpCounter for uniquely naming temporary variables
-	InValueExpr     bool // true when typing Value expressions of a LetStatement
+	InValueExpr     bool // true in value-position contexts (LetStatement conditions and values, and (cond value)): comparisons yield their LHS and chain, and || is the asymmetric fallback operator, rather than producing booleans. False in boolean contexts like function arguments.
 	UnresolvedExprs map[pendingBinding][]pendingExpr
 }
 

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -1568,13 +1568,11 @@ func (ts *TypeSolver) logicalOrValueType(leftType, rightType Type, tok token.Tok
 // type is the value's type. Slots are marked CondValue so the value gates on
 // lowering and the node can serve as the (failable) left operand of a value-position ||.
 func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []Type {
-	// The condition and the value are both value positions (comparisons yield their
-	// LHS and chain), so type both with InValueExpr set and restore on return. Every
-	// caller already types within a value/condition context (InValueExpr is true),
-	// so this is explicit-intent rather than strictly required.
-	savedInValueExpr := ts.InValueExpr
-	ts.InValueExpr = true
-	defer func() { ts.InValueExpr = savedInValueExpr }()
+	// The condition and value are both value positions (comparisons yield their LHS
+	// and chain). A (cond value) is only ever typed within a let condition or value,
+	// both already value context (InValueExpr true), so no flip is needed. A non-value
+	// caller would be caught loudly by the conditionCanFail check below — the cond
+	// would type as a plain boolean, not a failable comparison.
 	condTypes := ts.TypeExpression(expr.Cond, true)
 
 	if len(condTypes) != 1 {

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -558,9 +558,9 @@ func TestCondValueDiagnostics(t *testing.T) {
 		expectError string
 	}{
 		{
-			name:        "ConditionMustBeBoolean",
+			name:        "ConditionMustBeFailableComparison",
 			script:      "n = 5\nx = (n 10)",
-			expectError: "(cond value) condition must be a comparison or boolean, got I64",
+			expectError: "(cond value) condition must be a comparison that can fail, got I64",
 		},
 		{
 			// A (cond value) is a valid failable left operand of a value-position
@@ -625,9 +625,11 @@ func TestLogicalOrDiagnostics(t *testing.T) {
 			expectError: "logical OR value operands must have matching output types, got I64 and Str",
 		},
 		{
-			name:        "ConditionOperandsMustBeI1",
+			// Conditions are value-position now, so `a > 0 || b` is a fallback whose
+			// `b` arm always yields — the gate can never fail, which is rejected.
+			name:        "ConditionWithUnconditionalFallbackCannotGate",
 			script:      "a = 1\nb = 2\nx = a > 0 || b 7",
-			expectError: "logical OR requires condition operands, got I1 and I64",
+			expectError: "statement condition can never fail",
 		},
 	}
 

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -612,6 +612,14 @@ func TestLogicalOrDiagnostics(t *testing.T) {
 			expectError: "logical OR in value position requires a conditional left operand",
 		},
 		{
+			// A wrapped propagating condition can fail ((a > 2) + 1 || -1 is valid),
+			// but a wrapped (cond value) resolves locally and always produces a
+			// value, so the || would catch nothing — reject it.
+			name:        "WrappedLocalCondValueCannotFail",
+			script:      "a = 1\nx = (a > 2 5) + 1 || 7",
+			expectError: "logical OR in value position requires a conditional left operand",
+		},
+		{
 			name:        "FallbackTypesMustMatch",
 			script:      "a = 1\nx = a > 0 || \"fallback\"",
 			expectError: "logical OR value operands must have matching output types, got I64 and Str",

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -563,16 +563,6 @@ func TestCondValueDiagnostics(t *testing.T) {
 			expectError: "(cond value) condition must be a comparison or boolean, got I64",
 		},
 		{
-			name:        "RangesNotSupported",
-			script:      "i = 0:5\nr = (i > 2 i)",
-			expectError: "(cond value) does not support ranges yet",
-		},
-		{
-			name:        "RangeInValueNotSupported",
-			script:      "a = 5\ni = 0:5\nr = (a > 2 i)",
-			expectError: "(cond value) does not support ranges yet",
-		},
-		{
 			// A (cond value) is a valid failable left operand of a value-position
 			// ||; the fallback's type must still match the value's.
 			name:        "FallbackTypeMismatch",

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -572,6 +572,13 @@ func TestCondValueDiagnostics(t *testing.T) {
 			script:      "a = 5\ni = 0:5\nr = (a > 2 i)",
 			expectError: "(cond value) does not support ranges yet",
 		},
+		{
+			// A (cond value) is a valid failable left operand of a value-position
+			// ||; the fallback's type must still match the value's.
+			name:        "FallbackTypeMismatch",
+			script:      "a = 1\nx = (a > 0 10) || \"s\"",
+			expectError: "logical OR value operands must have matching output types, got I64 and Str",
+		},
 	}
 
 	for _, tc := range cases {

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -548,6 +548,58 @@ func TestScalarConditionEmitsTypeDiagnostic(t *testing.T) {
 	require.Contains(t, ts.Errors[0].Msg, "statement condition must be a comparison or bare range/array-range driver, got I64")
 }
 
+func TestCondValueDiagnostics(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+
+	cases := []struct {
+		name        string
+		script      string
+		expectError string
+	}{
+		{
+			name:        "ConditionMustBeBoolean",
+			script:      "n = 5\nx = (n 10)",
+			expectError: "(cond value) condition must be a comparison or boolean, got I64",
+		},
+		{
+			name:        "RangesNotSupported",
+			script:      "i = 0:5\nr = (i > 2 i)",
+			expectError: "(cond value) does not support ranges yet",
+		},
+		{
+			name:        "RangeInValueNotSupported",
+			script:      "a = 5\ni = 0:5\nr = (a > 2 i)",
+			expectError: "(cond value) does not support ranges yet",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cc := NewCodeCompiler(ctx, tc.name, "", ast.NewCode())
+			require.Empty(t, cc.Compile())
+
+			sl := lexer.New(tc.name+".spt", tc.script)
+			sp := parser.NewScriptParser(sl)
+			program := sp.Parse()
+			require.Empty(t, sp.Errors(), "unexpected parse errors: %v", sp.Errors())
+
+			sc := NewScriptCompiler(ctx, program, cc, make(map[string]*Func), make(map[ExprKey]*ExprInfo))
+			ts := NewTypeSolver(sc)
+			ts.Solve()
+
+			found := false
+			for _, err := range ts.Errors {
+				if strings.Contains(err.Msg, tc.expectError) {
+					found = true
+					break
+				}
+			}
+			require.Truef(t, found, "expected error containing %q, got: %v", tc.expectError, ts.Errors)
+		})
+	}
+}
+
 func TestLogicalOrDiagnostics(t *testing.T) {
 	ctx := llvm.NewContext()
 	defer ctx.Dispose()

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -554,6 +554,7 @@ func TestCondValueDiagnostics(t *testing.T) {
 
 	cases := []struct {
 		name        string
+		code        string
 		script      string
 		expectError string
 	}{
@@ -569,11 +570,23 @@ func TestCondValueDiagnostics(t *testing.T) {
 			script:      "a = 1\nx = (a > 0 10) || \"s\"",
 			expectError: "logical OR value operands must have matching output types, got I64 and Str",
 		},
+		{
+			// A multi-return comparison (Pair > Pair yields two values) cannot be a
+			// (cond value) condition — the gate must be a single value.
+			name:        "ConditionMustProduceSingleValue",
+			code:        "a, b = Pair(x, y)\n    a, b = x, y",
+			script:      "p, q = (Pair(1, 2) > Pair(3, 4)  7)",
+			expectError: "(cond value) condition must produce a single value",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cc := NewCodeCompiler(ctx, tc.name, "", ast.NewCode())
+			codeAST := ast.NewCode()
+			if strings.TrimSpace(tc.code) != "" {
+				codeAST = mustParseCode(t, tc.code)
+			}
+			cc := NewCodeCompiler(ctx, tc.name, "", codeAST)
 			require.Empty(t, cc.Compile())
 
 			sl := lexer.New(tc.name+".spt", tc.script)
@@ -629,6 +642,13 @@ func TestLogicalOrDiagnostics(t *testing.T) {
 			// `b` arm always yields — the gate can never fail, which is rejected.
 			name:        "ConditionWithUnconditionalFallbackCannotGate",
 			script:      "a = 1\nb = 2\nx = a > 0 || b 7",
+			expectError: "statement condition can never fail",
+		},
+		{
+			// Same, but deeper: only the final arm of the || chain is unconditional,
+			// so the whole chain still always yields and cannot gate.
+			name:        "DeepOrChainUnconditionalFinalArmCannotGate",
+			script:      "a = 1\nb = 2\nc = 3\nx = a > 0 || b > 5 || c 7",
 			expectError: "statement condition can never fail",
 		},
 	}

--- a/docs/Pluto Conditional Value Semantics.md
+++ b/docs/Pluto Conditional Value Semantics.md
@@ -32,6 +32,30 @@ new = b > 2  x * 3    # b <= 2 -> new = 0
 
 Multiple conditions separated by commas are ANDed; all must hold.
 
+### Conditions are value positions
+
+A condition is itself a value position: a comparison yields its LHS and chains,
+and the gate asks "did that value-position expression yield?" (the conjunction of
+its comparisons). So a chained comparison gates a range directly — the same
+`i > 2 < 8` that filters in value position:
+
+```pluto
+arr = i > 2 < 8  [i * i]      # gate on 2 < i < 8        -> [9 16 25 36 49]
+arr = [(i > 2 < 8  i * i)]    # same gate, per cell      -> [0 0 0 9 16 25 36 49 0 0]
+```
+
+This holds in every condition slot: a statement gate, a `(cond value)` condition,
+and a scalar gate. The same rule applies everywhere, so there is no separate
+"condition comparison" form to learn.
+
+Because the chain binds to the **leftmost** operand (the value-position rule),
+`i > 2 < 8` means `i > 2 AND i < 8`, but the math-natural `2 < i < 8` means just
+`2 < i` — the `< 8` chains onto the constant `2` (`2 < 8`, always true), not onto
+`i`. **Put the variable first** (`i > 2 < 8`), or use comma-AND (`i > 2, i < 8`),
+for a two-sided bound. A `||` in a condition is an OR gate (`a > 2 || b > 2`);
+its operands must have matching types and it must be able to fail (a `|| value`
+fallback that always yields cannot gate).
+
 ## Value position: a temporary, zero on false
 
 A conditional inside the value is a computed temporary. It yields its value when
@@ -162,9 +186,11 @@ them. See [Pluto Range Semantics](Pluto%20Range%20Semantics.md).
 
 - **Implemented:** statement gates (keep-old); `||` fallback in value and
   condition position; value-position comparisons (yield the left operand);
-  collector zero-fill; array filters; the parenthesized `(cond value)`
-  expression (local resolution to zero, with `|| fallback` and array-cell
-  zero-fill), including per-cell use inside array literals.
+  conditions are value positions, so chained comparisons gate directly
+  (`i > 2 < 8`, leftmost-binding) in every condition slot; collector zero-fill;
+  array filters; the parenthesized `(cond value)` expression (local resolution to
+  zero, with `|| fallback` and array-cell zero-fill), including per-cell use
+  inside array literals.
 - **Transitional inconsistency:** `(cond value)` resolves **locally** to zero,
   but a bare value-position comparison (`a > 2`) still **propagates** (keep-old).
   So `(a > 2 10) + 1` is `1` when `a <= 2` (local zero), while `(a > 2) + 1`

--- a/docs/Pluto Conditional Value Semantics.md
+++ b/docs/Pluto Conditional Value Semantics.md
@@ -118,6 +118,13 @@ zero, and `||` overrides.
 [i > 2 || -1]    # failed cells are -1
 ```
 
+Each cell resolves locally and independently — a failed cell zero-fills (or takes
+its `||` fallback) without gating the rest of the literal or the enclosing
+assignment. This holds whether the cells are scalar or range-driven: `[a > 99]`
+is `[0]` (not `[]`), and `[a > 2  a > 99]` is `[5 0]` (not empty or kept-old).
+This matches the `(cond value)` cell form exactly; a bare comparison and
+`(cond value)` are interchangeable as cells.
+
 Spacing separates cells, so parentheses also control cell count:
 
 ```pluto

--- a/docs/Pluto Conditional Value Semantics.md
+++ b/docs/Pluto Conditional Value Semantics.md
@@ -133,10 +133,13 @@ them. See [Pluto Range Semantics](Pluto%20Range%20Semantics.md).
 
 - **Implemented:** statement gates (keep-old); `||` fallback in value and
   condition position; value-position comparisons (yield the left operand);
-  collector zero-fill; array filters.
-- **Planned change:** nested value-position comparisons currently keep-old by
-  propagating out of the expression; the model above resolves them locally to
-  zero, matching a named temporary.
-- **Not yet implemented:** the parenthesized `(cond value)` form with an explicit
-  value, and per-cell conditionals inside array literals
-  (`[(a > 2 || 5) 7 (b > 7 || c)]`).
+  collector zero-fill; array filters; the parenthesized `(cond value)`
+  expression (local resolution to zero, with `|| fallback` and array-cell
+  zero-fill), including per-cell use inside array literals.
+- **Transitional inconsistency:** `(cond value)` resolves **locally** to zero,
+  but a bare value-position comparison (`a > 2`) still **propagates** (keep-old).
+  So `(a > 2 10) + 1` is `1` when `a <= 2` (local zero), while `(a > 2) + 1`
+  keeps the old value. They agree for new variables and inside array cells; they
+  differ only for existing variables and nested arithmetic.
+- **Planned change:** migrate bare value-position comparisons from propagation to
+  the same local resolution, removing the inconsistency above.

--- a/docs/Pluto Conditional Value Semantics.md
+++ b/docs/Pluto Conditional Value Semantics.md
@@ -83,6 +83,20 @@ a = 0
 a < 2 || 7           # a < 2 is true -> yields a (0), not 7
 ```
 
+The left operand need not be a bare conditional — it may **wrap** its condition
+in arithmetic. Because value-position conditions propagate (the whole value gates
+on them, the same conjunction that drives zero-fill), `||` attaches wherever a
+value can fail and swaps its fallback in for the zero:
+
+```pluto
+(i > 2 < 8) ^ 2 || -1.0   # i^2 when 2 < i < 8, else -1.0 (incl. i >= 8)
+(a > 2) + 100 || -1       # a + 100 when a > 2, else -1
+(a > 2) + (b > 3) || -1   # a + b when both hold (conditions AND), else -1
+```
+
+Only a left operand with **no** condition anywhere in its tree is rejected
+(`5 + 3 || -1`, `a || -1`) — there is nothing that can fail for `||` to catch.
+
 ## Parentheses group the condition
 
 At the top of a statement the `=` separates condition from value, so no

--- a/docs/Pluto Conditional Value Semantics.md
+++ b/docs/Pluto Conditional Value Semantics.md
@@ -100,6 +100,14 @@ second, `(a > 3 b < 5)` is a single conditional, so `|| 10` fires when `a > 3`
 fails, while a failing `b < 5` resolves locally to zero. A conditional resolves
 locally and never reaches back out to an enclosing operator.
 
+Wrapping the whole right-hand side keeps the bracket in value position, so
+`y = (a > 2 10)` is a plain value assignment — it **always** assigns (local
+resolution: `10` when `a > 2`, else `0`, overwriting `y`), and is treated as an
+unconditional write by the dead-store check. The unbracketed `y = a > 2 10` is
+instead a statement gate: it keeps `y`'s old value when `a <= 2`. Same-looking,
+deliberately different — the brackets choose value-position (local) over the
+gate (keep-old).
+
 ## Arrays
 
 A collector cell is a value position, so the same rule applies: a failed cell is

--- a/docs/Pluto Conditional Value Semantics.md
+++ b/docs/Pluto Conditional Value Semantics.md
@@ -143,7 +143,7 @@ them. See [Pluto Range Semantics](Pluto%20Range%20Semantics.md).
   differ only for existing variables and nested arithmetic.
 - **Planned change:** migrate bare value-position comparisons from propagation to
   the same local resolution, removing the inconsistency above.
-- **Not yet supported:** ranges inside a `(cond value)` (its scalar branch/phi
-  lowering does not iterate). `(cond value)` with a range in the condition or
-  value is rejected; use the comparison form (e.g. `[i > 2]`) for range-driven
-  conditional collection.
+- **Ranges:** a `(cond value)` may be range-driven. In a collector it iterates and
+  yields the per-iteration value or zero (`[(i > 2 i)]` → `[0 0 0 3 4]`,
+  `[(i > 2 i*10)]` → `[0 0 0 30 40]`); at an assignment root it keeps the final
+  iteration's value (`r = (i > 2 i)` → `4`).

--- a/docs/Pluto Conditional Value Semantics.md
+++ b/docs/Pluto Conditional Value Semantics.md
@@ -143,3 +143,7 @@ them. See [Pluto Range Semantics](Pluto%20Range%20Semantics.md).
   differ only for existing variables and nested arithmetic.
 - **Planned change:** migrate bare value-position comparisons from propagation to
   the same local resolution, removing the inconsistency above.
+- **Not yet supported:** ranges inside a `(cond value)` (its scalar branch/phi
+  lowering does not iterate). `(cond value)` with a range in the condition or
+  value is rejected; use the comparison form (e.g. `[i > 2]`) for range-driven
+  conditional collection.

--- a/docs/Pluto Range Semantics.md
+++ b/docs/Pluto Range Semantics.md
@@ -186,7 +186,7 @@ i = 0:10
 produces:
 
 ```pluto
-[0 0 0 3 4 5 6 7 0 0 0]
+[0 0 0 3 4 5 6 7 0 0]
 ```
 
 and
@@ -198,7 +198,7 @@ and
 produces:
 
 ```pluto
-[2 2 2 3 4 5 6 7 2 2 2]
+[2 2 2 3 4 5 6 7 2 2]
 ```
 
 `||` is resolved before the collector sees the final cell result, so explicit

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1251,7 +1251,10 @@ func (p *StmtParser) parseGroupedExpression() ast.Expression {
 	lparen := p.curToken
 	p.nextToken()
 
-	exp := p.parseExpression(LOWEST, prefixSplitNone)
+	// Parse the leading sub-expression with the same condition-split mode the
+	// statement level uses, so `(cond value)` detection (including attached
+	// prefixes like `a > 2 -b`) is discovered identically in both places.
+	exp := p.parseExpression(LOWEST, prefixSplitAfterCondition)
 	if exp == nil {
 		return nil
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1248,9 +1248,29 @@ func (p *StmtParser) parseInfixExpression(left ast.Expression) ast.Expression {
 }
 
 func (p *StmtParser) parseGroupedExpression() ast.Expression {
+	lparen := p.curToken
 	p.nextToken()
 
 	exp := p.parseExpression(LOWEST, prefixSplitNone)
+	if exp == nil {
+		return nil
+	}
+
+	// (cond value): a parenthesized conditional value. Recognized when the first
+	// sub-expression is a condition and a value follows before the ')'. A bare
+	// `(cond)` (no value) stays an ordinary value-position expression, and a
+	// trailing `|| fallback` binds outside the parens as a normal infix.
+	if p.isCondition(exp) && !p.peekTokenIs(token.RPAREN) {
+		p.nextToken()
+		value := p.parseExpression(LOWEST, prefixSplitNone)
+		if value == nil {
+			return nil
+		}
+		if !p.expectPeek(token.RPAREN) {
+			return nil
+		}
+		return &ast.CondValueExpr{Token: lparen, Cond: exp, Value: value}
+	}
 
 	if !p.expectPeek(token.RPAREN) {
 		return nil

--- a/parser/scriptparser_test.go
+++ b/parser/scriptparser_test.go
@@ -956,6 +956,33 @@ func TestParenGroupingUnaffected(t *testing.T) {
 	require.Truef(t, testInfixExpression(t, stmt.Value[0], "x", "+", 1), "expected plain grouped expr")
 }
 
+func TestCondValueAttachedPrefixSharedDetection(t *testing.T) {
+	// `(a > 2 -b)` splits on the attached prefix `-b` (cond `a > 2`, value `-b`)
+	// using the same condition-split mode as the statement level, so detection is
+	// consistent. `(a - b)` (spaced) stays ordinary subtraction.
+	const input = "x = (a > 2 -b)"
+	sp := NewScriptParser(lexer.New("TestCondValueAttachedPrefixSharedDetection", input))
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Len(t, stmt.Value, 1, "expected one value")
+	cv, ok := stmt.Value[0].(*ast.CondValueExpr)
+	require.Truef(t, ok, "expected *ast.CondValueExpr, got %T", stmt.Value[0])
+	require.Truef(t, testInfixExpression(t, cv.Cond, "a", ">", 2), "cond mismatch")
+	pre, ok := cv.Value.(*ast.PrefixExpression)
+	require.Truef(t, ok, "expected prefix value, got %T", cv.Value)
+	require.Equal(t, "-", pre.Operator)
+	require.Truef(t, testIdentifier(t, pre.Right, "b"), "value operand mismatch")
+
+	// Spaced subtraction is unaffected.
+	sp2 := NewScriptParser(lexer.New("paren-sub", "y = (a - b)"))
+	prog2 := sp2.Parse()
+	require.Empty(t, sp2.Errors())
+	st2 := requireOnlyLetStmt(t, prog2)
+	require.Truef(t, testInfixExpression(t, st2.Value[0], "a", "-", "b"), "spaced subtraction should be plain")
+}
+
 // Function call in condition
 func TestFunctionCallInCondition(t *testing.T) {
 	const input = "res = pow(2, 3) > 8 result"

--- a/parser/scriptparser_test.go
+++ b/parser/scriptparser_test.go
@@ -977,6 +977,21 @@ func TestParenGroupingUnaffected(t *testing.T) {
 	require.Truef(t, testInfixExpression(t, stmt.Value[0], "x", "+", 1), "expected plain grouped expr")
 }
 
+func TestParenGroupedIdentifierThenInfix(t *testing.T) {
+	// isCondition treats a bare identifier as a condition, so only the peek-RPAREN
+	// guard keeps `(a)` ordinary grouping: `(a) + 1` must be `a + 1`, not a CondValueExpr.
+	const input = "x = (a) + 1"
+	sp := NewScriptParser(lexer.New("TestParenGroupedIdentifierThenInfix", input))
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Len(t, stmt.Value, 1, "expected one value")
+	_, isCV := stmt.Value[0].(*ast.CondValueExpr)
+	require.Falsef(t, isCV, "(a) + 1 must not become a CondValueExpr")
+	require.Truef(t, testInfixExpression(t, stmt.Value[0], "a", "+", 1), "expected plain grouped expr a + 1")
+}
+
 func TestCondValueAttachedPrefixSharedDetection(t *testing.T) {
 	// `(a > 2 -b)` splits on the attached prefix `-b` (cond `a > 2`, value `-b`)
 	// using the same condition-split mode as the statement level, so detection is

--- a/parser/scriptparser_test.go
+++ b/parser/scriptparser_test.go
@@ -878,6 +878,84 @@ func TestLogicalOrDoesNotConsumeBitwiseOr(t *testing.T) {
 	require.Truef(t, testInfixExpression(t, stmt.Value[0], 6, "|", 3), "bitwise OR value mismatch")
 }
 
+func TestCondValueExpr(t *testing.T) {
+	const input = "x = (a > 2 10)"
+	sp := NewScriptParser(lexer.New("TestCondValueExpr", input))
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Empty(t, stmt.Condition)
+	require.Len(t, stmt.Value, 1, "expected one value")
+	cv, ok := stmt.Value[0].(*ast.CondValueExpr)
+	require.Truef(t, ok, "expected *ast.CondValueExpr, got %T", stmt.Value[0])
+	require.Truef(t, testInfixExpression(t, cv.Cond, "a", ">", 2), "cond mismatch")
+	require.Truef(t, testIntegerLiteral(t, cv.Value, 10), "value mismatch")
+}
+
+func TestCondValueExprWithFallback(t *testing.T) {
+	// The trailing `|| 7` binds OUTSIDE the parens as a normal infix.
+	const input = "x = (a > 2 10) || 7"
+	sp := NewScriptParser(lexer.New("TestCondValueExprWithFallback", input))
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Len(t, stmt.Value, 1, "expected one value")
+	or, ok := stmt.Value[0].(*ast.InfixExpression)
+	require.Truef(t, ok, "expected *ast.InfixExpression, got %T", stmt.Value[0])
+	require.Equal(t, "||", or.Operator)
+	cv, ok := or.Left.(*ast.CondValueExpr)
+	require.Truef(t, ok, "expected CondValueExpr on the left of ||, got %T", or.Left)
+	require.Truef(t, testInfixExpression(t, cv.Cond, "a", ">", 2), "cond mismatch")
+	require.Truef(t, testIntegerLiteral(t, cv.Value, 10), "value mismatch")
+	require.Truef(t, testIntegerLiteral(t, or.Right, 7), "fallback mismatch")
+}
+
+func TestCondValueExprInArray(t *testing.T) {
+	const input = "x = [1 (a > 2 5) 3]"
+	sp := NewScriptParser(lexer.New("TestCondValueExprInArray", input))
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Len(t, stmt.Value, 1, "expected one value")
+	arr, ok := stmt.Value[0].(*ast.ArrayLiteral)
+	require.Truef(t, ok, "expected *ast.ArrayLiteral, got %T", stmt.Value[0])
+	require.Len(t, arr.Rows, 1)
+	require.Len(t, arr.Rows[0], 3, "expected three cells")
+	cv, ok := arr.Rows[0][1].(*ast.CondValueExpr)
+	require.Truef(t, ok, "expected CondValueExpr cell, got %T", arr.Rows[0][1])
+	require.Truef(t, testInfixExpression(t, cv.Cond, "a", ">", 2), "cell cond mismatch")
+	require.Truef(t, testIntegerLiteral(t, cv.Value, 5), "cell value mismatch")
+}
+
+func TestParenComparisonStaysPlain(t *testing.T) {
+	// `(a > 2)` with no value is a plain value-position comparison, not a CondValueExpr.
+	const input = "x = (a > 2)"
+	sp := NewScriptParser(lexer.New("TestParenComparisonStaysPlain", input))
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Len(t, stmt.Value, 1, "expected one value")
+	_, isCV := stmt.Value[0].(*ast.CondValueExpr)
+	require.Falsef(t, isCV, "bare (a > 2) must not become a CondValueExpr")
+	require.Truef(t, testInfixExpression(t, stmt.Value[0], "a", ">", 2), "expected plain comparison")
+}
+
+func TestParenGroupingUnaffected(t *testing.T) {
+	// `(x + 1)` is not a condition, so it stays ordinary grouping.
+	const input = "y = (x + 1)"
+	sp := NewScriptParser(lexer.New("TestParenGroupingUnaffected", input))
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Len(t, stmt.Value, 1, "expected one value")
+	require.Truef(t, testInfixExpression(t, stmt.Value[0], "x", "+", 1), "expected plain grouped expr")
+}
+
 // Function call in condition
 func TestFunctionCallInCondition(t *testing.T) {
 	const input = "res = pow(2, 3) > 8 result"

--- a/parser/scriptparser_test.go
+++ b/parser/scriptparser_test.go
@@ -535,6 +535,27 @@ func TestConditionExpression(t *testing.T) {
 	}
 }
 
+func TestCondValueParseErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expErr string
+	}{
+		{"missing closing paren", "a = 5\nr = (a > 2 10", "expected next token to be )"},
+		{"extra expression", "a = 5\nr = (a > 2 10 20)", "expected next token to be )"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := lexer.New("TestCondValueParseErrors", tt.input)
+			sp := NewScriptParser(l)
+			sp.Parse()
+			errs := sp.Errors()
+			require.NotEmptyf(t, errs, "input %q: expected a parse error", tt.input)
+			require.Containsf(t, errs[0], tt.expErr, "input %q: unexpected error %v", tt.input, errs)
+		})
+	}
+}
+
 func TestConditionThenArrayValue(t *testing.T) {
 	const input = "x = a > b [1 2 3]"
 	l := lexer.New("TestConditionThenArrayValue", input)

--- a/tests/cond/cond_value.exp
+++ b/tests/cond/cond_value.exp
@@ -33,3 +33,5 @@ CvArrCellOob: [10 20 0 0 0]
 CvArrCellOobExpr: [20 40 0 0 0]
 CvCellRangeVal: [2 4 6 8 10]
 CvCellMultiDriver: [2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 4 6 8 10]
+CvRootArith: 19
+CvRootHeap: his4

--- a/tests/cond/cond_value.exp
+++ b/tests/cond/cond_value.exp
@@ -21,3 +21,5 @@ CvMultiTrue: 10 20
 CvMultiFalse: 0 0
 CvNested: 5
 CvCallArg: 20
+CvOrTrue: 10
+CvOrFalse: 0

--- a/tests/cond/cond_value.exp
+++ b/tests/cond/cond_value.exp
@@ -23,3 +23,7 @@ CvNested: 5
 CvCallArg: 20
 CvOrTrue: 10
 CvOrFalse: 0
+CvRangeArr: [0 0 0 3 4]
+CvRangeArrCustom: [0 0 0 30 40]
+CvRangeRoot: 4
+CvRangeRootFalseFinal: 0

--- a/tests/cond/cond_value.exp
+++ b/tests/cond/cond_value.exp
@@ -31,3 +31,5 @@ CvRangeHeap: s4
 CvRangeOob: 20
 CvArrCellOob: [10 20 0 0 0]
 CvArrCellOobExpr: [20 40 0 0 0]
+CvCellRangeVal: [2 4 6 8 10]
+CvCellMultiDriver: [2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 4 6 8 10]

--- a/tests/cond/cond_value.exp
+++ b/tests/cond/cond_value.exp
@@ -17,3 +17,5 @@ CvFloat: 2.5
 CvStrTrue: hello world
 re:CvStrFalse:\s*
 CvStrFb: fallback
+CvMultiTrue: 10 20
+CvMultiFalse: 0 0

--- a/tests/cond/cond_value.exp
+++ b/tests/cond/cond_value.exp
@@ -27,3 +27,5 @@ CvRangeArr: [0 0 0 3 4]
 CvRangeArrCustom: [0 0 0 30 40]
 CvRangeRoot: 4
 CvRangeRootFalseFinal: 0
+CvRangeHeap: s4
+CvRangeOob: 20

--- a/tests/cond/cond_value.exp
+++ b/tests/cond/cond_value.exp
@@ -19,3 +19,5 @@ re:CvStrFalse:\s*
 CvStrFb: fallback
 CvMultiTrue: 10 20
 CvMultiFalse: 0 0
+CvNested: 5
+CvCallArg: 20

--- a/tests/cond/cond_value.exp
+++ b/tests/cond/cond_value.exp
@@ -1,0 +1,19 @@
+CvTrue: 10
+CvFalseNew: 0
+CvExistingBefore: 42
+CvExistingFalse: 0
+CvArithTrue: 11
+CvArithFalse: 1
+CvDeep: 23
+CvExprValue: 105
+CvFbTrue: 10
+CvFbFalse: 7
+CvFbVar: 5
+CvArrTrue: [1 5 3]
+CvArrFalse: [1 0 3]
+CvArrMulti: [9 0 7]
+CvArrFb: [-1 7]
+CvFloat: 2.5
+CvStrTrue: hello world
+re:CvStrFalse:\s*
+CvStrFb: fallback

--- a/tests/cond/cond_value.exp
+++ b/tests/cond/cond_value.exp
@@ -29,3 +29,5 @@ CvRangeRoot: 4
 CvRangeRootFalseFinal: 0
 CvRangeHeap: s4
 CvRangeOob: 20
+CvArrCellOob: [10 20 0 0 0]
+CvArrCellOobExpr: [20 40 0 0 0]

--- a/tests/cond/cond_value.spt
+++ b/tests/cond/cond_value.spt
@@ -98,3 +98,16 @@ cvOrTrue = (a > 2 || b > 5 10)
 "CvOrTrue: -cvOrTrue"
 cvOrFalse = (b > 2 || b > 5 10)
 "CvOrFalse: -cvOrFalse"
+
+# Range-driven: in a collector it iterates and zero-fills failed cells; the
+# value may be an arbitrary per-iteration expression (which the comparison form
+# cannot yield). At an assignment root it keeps the final iteration's value.
+gi = 0:5
+cvRangeArr = [(gi > 2 gi)]
+"CvRangeArr: -cvRangeArr"
+cvRangeArrCustom = [(gi > 2 gi * 10)]
+"CvRangeArrCustom: -cvRangeArrCustom"
+cvRangeRoot = (gi > 2 gi)
+"CvRangeRoot: -cvRangeRoot"
+cvRangeRootFalseFinal = (gi < 2 gi)
+"CvRangeRootFalseFinal: -cvRangeRootFalseFinal"

--- a/tests/cond/cond_value.spt
+++ b/tests/cond/cond_value.spt
@@ -122,3 +122,11 @@ cvRangeHeap = (gi >= 0 MkStr(gi))
 cvBounds = [10 20]
 cvRangeOob = (gi >= 0 cvBounds[gi])
 "CvRangeOob: -cvRangeOob"
+
+# Bracketed (cond value) cell with an out-of-bounds access: in-bounds cells take
+# the value, out-of-bounds cells zero-fill (the collector's per-cell bounds
+# guard), and the value may be an arbitrary expression.
+cvArrCellOob = [(gi >= 0 cvBounds[gi])]
+"CvArrCellOob: -cvArrCellOob"
+cvArrCellOobExpr = [(gi >= 0 cvBounds[gi] * 2)]
+"CvArrCellOobExpr: -cvArrCellOobExpr"

--- a/tests/cond/cond_value.spt
+++ b/tests/cond/cond_value.spt
@@ -77,3 +77,10 @@ cvStrFalse = (b > 2 sl ⊕ sm)
 "CvStrFalse: -cvStrFalse"
 cvStrFb = (b > 2 sl ⊕ sm) || "fallback"
 "CvStrFb: -cvStrFb"
+
+# Multi-return value: condition true yields all values, false yields the zero
+# of each output slot (one branch/phi per returned value).
+cvMultiA, cvMultiB = (a > 2 Pair(10, 20))
+"CvMultiTrue: -cvMultiA -cvMultiB"
+cvMultiC, cvMultiD = (b > 2 Pair(10, 20))
+"CvMultiFalse: -cvMultiC -cvMultiD"

--- a/tests/cond/cond_value.spt
+++ b/tests/cond/cond_value.spt
@@ -84,3 +84,11 @@ cvMultiA, cvMultiB = (a > 2 Pair(10, 20))
 "CvMultiTrue: -cvMultiA -cvMultiB"
 cvMultiC, cvMultiD = (b > 2 Pair(10, 20))
 "CvMultiFalse: -cvMultiC -cvMultiD"
+
+# Nested: the value is itself a (cond value).
+cvNested = (a > 2 (a > 4 5))
+"CvNested: -cvNested"
+
+# As a call argument.
+cvCallArg = Double((a > 2 10))
+"CvCallArg: -cvCallArg"

--- a/tests/cond/cond_value.spt
+++ b/tests/cond/cond_value.spt
@@ -92,3 +92,9 @@ cvNested = (a > 2 (a > 4 5))
 # As a call argument.
 cvCallArg = Double((a > 2 10))
 "CvCallArg: -cvCallArg"
+
+# Compound boolean-OR condition.
+cvOrTrue = (a > 2 || b > 5 10)
+"CvOrTrue: -cvOrTrue"
+cvOrFalse = (b > 2 || b > 5 10)
+"CvOrFalse: -cvOrFalse"

--- a/tests/cond/cond_value.spt
+++ b/tests/cond/cond_value.spt
@@ -111,3 +111,14 @@ cvRangeRoot = (gi > 2 gi)
 "CvRangeRoot: -cvRangeRoot"
 cvRangeRootFalseFinal = (gi < 2 gi)
 "CvRangeRootFalseFinal: -cvRangeRootFalseFinal"
+
+# Range-root with a heap value frees the previous iteration before overwriting
+# (no leak across iterations); the final iteration's string wins.
+cvRangeHeap = (gi >= 0 MkStr(gi))
+"CvRangeHeap: -cvRangeHeap"
+
+# Range-root array access: out-of-bounds iterations skip the store and keep the
+# last in-bounds value (respects the active bounds guard).
+cvBounds = [10 20]
+cvRangeOob = (gi >= 0 cvBounds[gi])
+"CvRangeOob: -cvRangeOob"

--- a/tests/cond/cond_value.spt
+++ b/tests/cond/cond_value.spt
@@ -1,0 +1,79 @@
+# Parenthesized conditional value (cond value): yields value when cond holds,
+# otherwise resolves locally to the zero value. A trailing `|| fallback`
+# overrides the zero; inside `[]` a failed cell zero-fills.
+a = 5
+b = 1
+
+# Standalone, condition true.
+cvTrue = (a > 2 10)
+"CvTrue: -cvTrue"
+
+# Standalone, condition false, new variable -> zero.
+cvFalseNew = (b > 2 10)
+"CvFalseNew: -cvFalseNew"
+
+# Existing variable, condition false -> overwritten with zero (local resolution).
+cvExisting = 42
+"CvExistingBefore: -cvExisting"
+cvExisting = (b > 2 10)
+"CvExistingFalse: -cvExisting"
+
+# Nested in arithmetic, condition true -> 10 + 1.
+cvArithTrue = (a > 2 10) + 1
+"CvArithTrue: -cvArithTrue"
+
+# Nested in arithmetic, condition false -> 0 + 1 (local resolution).
+cvArithFalse = (b > 2 10) + 1
+"CvArithFalse: -cvArithFalse"
+
+# Deeper nesting: 2*(a>2 10) + (b>0 3) = 20 + 3.
+cvDeep = 2 * (a > 2 10) + (b > 0 3)
+"CvDeep: -cvDeep"
+
+# Value is an arbitrary expression.
+cvExprValue = (a > 2 a + 100)
+"CvExprValue: -cvExprValue"
+
+# Fallback ||: condition true keeps the value.
+cvFbTrue = (a > 2 10) || 7
+"CvFbTrue: -cvFbTrue"
+
+# Fallback ||: condition false uses the fallback.
+cvFbFalse = (b > 2 10) || 7
+"CvFbFalse: -cvFbFalse"
+
+# Fallback to a variable.
+cvFbVar = (b > 2 10) || a
+"CvFbVar: -cvFbVar"
+
+# Array: conditional cell true.
+cvArrTrue = [1 (a > 2 5) 3]
+"CvArrTrue: -cvArrTrue"
+
+# Array: conditional cell false -> zero-fill.
+cvArrFalse = [1 (b > 2 5) 3]
+"CvArrFalse: -cvArrFalse"
+
+# Array: multiple conditional cells.
+cvArrMulti = [(a > 2 9) (b > 2 9) (a > 0 7)]
+"CvArrMulti: -cvArrMulti"
+
+# Array: conditional cell with a fallback override.
+cvArrFb = [(b > 2 5) || -1 7]
+"CvArrFb: -cvArrFb"
+
+# Float value.
+f = 2.5
+cvFloat = (a > 2 f)
+"CvFloat: -cvFloat"
+
+# Heap string value (concatenation) gated by a condition; exercises ownership
+# of the branch/zero/fallback arms (no leak, no double-free).
+sl = "hello"
+sm = " world"
+cvStrTrue = (a > 2 sl ⊕ sm)
+"CvStrTrue: -cvStrTrue"
+cvStrFalse = (b > 2 sl ⊕ sm)
+"CvStrFalse: -cvStrFalse"
+cvStrFb = (b > 2 sl ⊕ sm) || "fallback"
+"CvStrFb: -cvStrFb"

--- a/tests/cond/cond_value.spt
+++ b/tests/cond/cond_value.spt
@@ -144,3 +144,14 @@ cvCellRangeVal = [cvX + (cvA > 3 2gi)]
 cvAR = 0:5
 cvCellMultiDriver = [cvX + (cvAR > 3 2gi)]
 "CvCellMultiDriver: -cvCellMultiDriver"
+
+# (cond value) as an arithmetic operand at a statement root (no collector): the
+# enclosing operator owns the loop, so it keeps the final iteration's value.
+cvRootArith = cvX + (cvA > 2 3gi + 5)
+"CvRootArith: -cvRootArith"
+
+# Heap value at a root: the per-iteration concat result is freed before the next
+# overwrite (no leak across iterations), and the final iteration's value wins.
+cvSm = "hi"
+cvRootHeap = cvSm ⊕ (cvA > 2 MkStr(gi))
+"CvRootHeap: -cvRootHeap"

--- a/tests/cond/cond_value.spt
+++ b/tests/cond/cond_value.spt
@@ -130,3 +130,17 @@ cvArrCellOob = [(gi >= 0 cvBounds[gi])]
 "CvArrCellOob: -cvArrCellOob"
 cvArrCellOobExpr = [(gi >= 0 cvBounds[gi] * 2)]
 "CvArrCellOobExpr: -cvArrCellOobExpr"
+
+# (cond value) nested in arithmetic inside a collector, with a scalar condition
+# gating a range-driven value: 2 + 2*gi per iteration.
+cvX = 2
+cvA = 4
+cvCellRangeVal = [cvX + (cvA > 3 2gi)]
+"CvCellRangeVal: -cvCellRangeVal"
+
+# Multi-driver: the condition ranges on one driver and the value on another, so
+# the collector nests them (cvAR outer, gi inner). Only cvAR == 4 admits 2*gi;
+# every other cvAR yields 0, leaving 2 + 0.
+cvAR = 0:5
+cvCellMultiDriver = [cvX + (cvAR > 3 2gi)]
+"CvCellMultiDriver: -cvCellMultiDriver"

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -101,3 +101,9 @@ HcOrShortCircuit: 7
 HcCondCell: [7]
 HcCondAndValueCell: [s1]
 HcRangedCond: [0 1 2]
+ArithGateTrue: 17
+ArithGateKeepBefore: 99
+ArithGateKeep: 99
+ArithGateHeapTrue: foobar
+ArithGateHeapKeepBefore: OLD
+ArithGateHeapKeep: OLD

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -132,3 +132,11 @@ ChainKeepAfter: 99
 ChainLeftmost: [0 0 0 2 2 2 2 2 2 2]
 ChainGateHeap: [3 4 5 6 7]
 ChainCondValHeap: [0 0 0 3 4 5 6 7 0 0]
+RootCondPrintTrue:
+10
+RootCondPrintFalse:
+0
+RootChainPrint:
+25
+RootChainPrintFalse:
+0

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -115,3 +115,4 @@ OrWrapHeapTrue: s5!
 OrWrapHeapFalse: def
 OrWrapHeapCell: [def def def def def def def s7! s8! s9!]
 OrWrapRepeatedCond: [-1 -1 -1 9 16 25 36 49 -1 -1]
+OwPiecewise: [-10 -10 0 0 0 25 36 49 999 999]

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -114,3 +114,4 @@ OrWrapMulti: -1
 OrWrapHeapTrue: s5!
 OrWrapHeapFalse: def
 OrWrapHeapCell: [def def def def def def def s7! s8! s9!]
+OrWrapRepeatedCond: [-1 -1 -1 9 16 25 36 49 -1 -1]

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -93,3 +93,11 @@ HeapCmpFalse: []
 HeapCmpMulti: [s5 s1]
 HeapCondvalOrTrue: [s5]
 HeapCondvalOrFalse: [def]
+HcCondTrue: 7
+HcCondFalse: 0
+HcBothSides: 7
+HcAnded: 7
+HcOrShortCircuit: 7
+HcCondCell: [7]
+HcCondAndValueCell: [s1]
+HcRangedCond: [0 1 2]

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -84,3 +84,12 @@ LogicalOrBoundaryRightBefore: 100
 LogicalOrBoundaryRightCondFallback: -1
 LogicalOrBoundarySkipBefore: 100
 LogicalOrBoundarySkipKeepsDefault: 100
+ScalarCmpCellTrue: [5]
+ScalarCmpCellFalse: [0]
+ScalarCmpMulti: [5 0]
+ScalarCmpFb: [-1]
+HeapCmpCell: [s5]
+HeapCmpFalse: []
+HeapCmpMulti: [s5 s1]
+HeapCondvalOrTrue: [s5]
+HeapCondvalOrFalse: [def]

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -116,3 +116,10 @@ OrWrapHeapFalse: def
 OrWrapHeapCell: [def def def def def def def s7! s8! s9!]
 OrWrapRepeatedCond: [-1 -1 -1 9 16 25 36 49 -1 -1]
 OwPiecewise: [-10 -10 0 0 0 25 36 49 999 999]
+ChainGate: [9 16 25 36 49]
+ChainCondVal: [0 0 0 9 16 25 36 49 0 0]
+ChainCondValFb: [-1 -1 -1 9 16 25 36 49 -1 -1]
+ChainScalar: 25
+ChainKeepBefore: 99
+ChainKeepAfter: 99
+ChainLeftmost: [0 0 0 2 2 2 2 2 2 2]

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -102,6 +102,9 @@ HcOrFallThrough: 7
 HcOrAllFail: 0
 ScOrShortCircuit: 7
 ScOrSecondArmRuns: 0
+OrGateHeap: 7
+OrGateRanged: [3 4]
+OrGateRangedAllFail: []
 HcCondCell: [7]
 HcCondAndValueCell: [s1]
 HcRangedCond: [0 1 2]

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -98,6 +98,8 @@ HcCondFalse: 0
 HcBothSides: 7
 HcAnded: 7
 HcOrShortCircuit: 7
+HcOrFallThrough: 7
+HcOrAllFail: 0
 HcCondCell: [7]
 HcCondAndValueCell: [s1]
 HcRangedCond: [0 1 2]

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -123,3 +123,5 @@ ChainScalar: 25
 ChainKeepBefore: 99
 ChainKeepAfter: 99
 ChainLeftmost: [0 0 0 2 2 2 2 2 2 2]
+ChainGateHeap: [3 4 5 6 7]
+ChainCondValHeap: [0 0 0 3 4 5 6 7 0 0]

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -107,3 +107,10 @@ ArithGateKeep: 99
 ArithGateHeapTrue: foobar
 ArithGateHeapKeepBefore: OLD
 ArithGateHeapKeep: OLD
+OrWrapPow: [-1 -1 -1 9 16 25 36 49 -1 -1]
+OrWrapAddTrue: 105
+OrWrapAddFalse: -1
+OrWrapMulti: -1
+OrWrapHeapTrue: s5!
+OrWrapHeapFalse: def
+OrWrapHeapCell: [def def def def def def def s7! s8! s9!]

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -100,6 +100,8 @@ HcAnded: 7
 HcOrShortCircuit: 7
 HcOrFallThrough: 7
 HcOrAllFail: 0
+ScOrShortCircuit: 7
+ScOrSecondArmRuns: 0
 HcCondCell: [7]
 HcCondAndValueCell: [s1]
 HcRangedCond: [0 1 2]

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -380,7 +380,7 @@ hcBothSides = (MkStr(a) > MkStr(b) 7)
 "HcBothSides: -hcBothSides"
 hcAnded = MkStr(a) > "a", MkStr(b) > "a" 7
 "HcAnded: -hcAnded"
-hcOrShortCircuit = (a > 2 || MkStr(b) > "a" 7)
+hcOrShortCircuit = (MkStr(a) > "a" || MkStr(b) > "zzz" 7)
 "HcOrShortCircuit: -hcOrShortCircuit"
 hcCondCell = [(MkStr(a) > "a" 7)]
 "HcCondCell: -hcCondCell"
@@ -449,3 +449,30 @@ orWrapRepeatedCond = [(owI > 2 < 8) * (owI > 2 < 8) || -1]
 # filtered pieces). Here: owI < 2 -> -10, else < 5 -> 0, else < 8 -> owI^2, else 999.
 owPiecewise = [(owI < 2 -10) || (owI < 5 0) || (owI < 8 owI * owI) || 999]
 "OwPiecewise: -owPiecewise"
+
+# Conditions are value-position like the values: a comparison yields its LHS and
+# chains, so a chained comparison gates a range directly — the same `i > 2 < 8`
+# that filters in value position. Works in every condition slot: a statement gate,
+# a (cond value) condition (with or without a || fallback), and a scalar gate.
+chI = 0:10
+chainGate = chI > 2 < 8 [chI * chI]
+"ChainGate: -chainGate"
+chainCondVal = [(chI > 2 < 8  chI * chI)]
+"ChainCondVal: -chainCondVal"
+chainCondValFb = [(chI > 2 < 8  chI * chI) || -1]
+"ChainCondValFb: -chainCondValFb"
+chA = 5
+chainScalar = chA > 2 < 8  chA * chA
+"ChainScalar: -chainScalar"
+chainKeep = 99
+"ChainKeepBefore: -chainKeep"
+chB = 10
+chainKeep = chB > 2 < 8  chB * chB
+"ChainKeepAfter: -chainKeep"
+
+# Chaining binds to the leftmost operand (the value-position rule), so the
+# math-natural `2 < i < 8` means `2 < i` — the `< 8` chains onto the constant `2`
+# (2 < 8, always true), not onto `i`. Write the variable first (`i > 2 < 8`) or use
+# comma-AND (`i > 2, i < 8`) for a two-sided bound. This documents the behaviour.
+chainLeftmost = [2 < chI < 8]
+"ChainLeftmost: -chainLeftmost"

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -389,3 +389,25 @@ hcCondAndValueCell = [(MkStr(a) > "a" MkStr(b))]
 hcRng = 0:3
 hcRangedCond = [(MkStr(hcRng) > "s0" hcRng)]
 "HcRangedCond: -hcRangedCond"
+
+# Comparison binds tighter than arithmetic/concat, so `x + y > k` is `x + (y > k)`:
+# compute `x + y` gated by the trailing comparison, otherwise propagate (skip,
+# keeping the old value). The arithmetic operand's heap value computed before a
+# failed gate is dropped without leaking. (To gate on the sum itself, parenthesize:
+# `(x + y) > k`.)
+agX = 10
+agY = 7
+arithGateTrue = agX + agY > 5
+"ArithGateTrue: -arithGateTrue"
+arithGateKeep = 99
+"ArithGateKeepBefore: -arithGateKeep"
+arithGateKeep = agX + agY > 50
+"ArithGateKeep: -arithGateKeep"
+agS1 = "foo"
+agS2 = "bar"
+arithGateHeapTrue = agS1 ⊕ agS2 > "a"
+"ArithGateHeapTrue: -arithGateHeapTrue"
+arithGateHeapKeep = "OLD"
+"ArithGateHeapKeepBefore: -arithGateHeapKeep"
+arithGateHeapKeep = agS1 ⊕ agS2 > "zzz"
+"ArithGateHeapKeep: -arithGateHeapKeep"

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -411,3 +411,26 @@ arithGateHeapKeep = "OLD"
 "ArithGateHeapKeepBefore: -arithGateHeapKeep"
 arithGateHeapKeep = agS1 ⊕ agS2 > "zzz"
 "ArithGateHeapKeep: -arithGateHeapKeep"
+
+# A fallback || may attach to a left operand that WRAPS its condition in
+# arithmetic, not only to a bare conditional: the whole value is gated on the
+# nested condition (matching value-position propagation / zero-fill), and || just
+# swaps its fallback in for the zero. So `(i > 2 < 8) ^ 2 || -1.0` is i^2 when
+# 2 < i < 8 and -1 otherwise (including i >= 8) — the natural one-liner. Multiple
+# nested conditions are ANDed; the fallback fires if any fail. (Heap arms below
+# are leak-checked, including the value computed before a failed gate.)
+owI = 0:10
+orWrapPow = [(owI > 2 < 8) ^ 2 || -1.0]
+"OrWrapPow: -orWrapPow"
+orWrapAddTrue = (a > 2) + 100 || -1
+"OrWrapAddTrue: -orWrapAddTrue"
+orWrapAddFalse = (b > 2) + 100 || -1
+"OrWrapAddFalse: -orWrapAddFalse"
+orWrapMulti = (a > 2) + (b > 3) || -1
+"OrWrapMulti: -orWrapMulti"
+orWrapHeapTrue = (MkStr(a) > "s2") ⊕ "!" || "def"
+"OrWrapHeapTrue: -orWrapHeapTrue"
+orWrapHeapFalse = (MkStr(b) > "s2") ⊕ "!" || "def"
+"OrWrapHeapFalse: -orWrapHeapFalse"
+orWrapHeapCell = [(MkStr(owI) > "s6") ⊕ "!" || "def"]
+"OrWrapHeapCell: -orWrapHeapCell"

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -401,6 +401,20 @@ scOrShortCircuit = (1 < 2 || scOob[5] < 5  7)
 "ScOrShortCircuit: -scOrShortCircuit"
 scOrSecondArmRuns = (1 > 2 || scOob[5] < 5  7)
 "ScOrSecondArmRuns: -scOrSecondArmRuns"
+
+# Statement-gate || with heap operands — a distinct path from the (cond value) ||
+# slot: compileGate is reached from evalConditions, and per-iteration inside the
+# loop for a ranged gate. The heap LHS computed for each arm must be freed on every
+# evaluation. Scalar (arm1 wins), ranged (some iterations admitted), and ranged
+# where every iteration fails both arms (so it computes and frees both heap LHS per
+# step and admits nothing) — all leak-checked by the suite.
+orGateHeap = MkStr(a) > "a" || MkStr(b) > "zzz"  7
+"OrGateHeap: -orGateHeap"
+orR = 0:5
+orGateRanged = MkStr(orR) > "s2" || MkStr(orR) > "zzz" [orR]
+"OrGateRanged: -orGateRanged"
+orGateRangedAllFail = MkStr(orR) > "zzz" || MkStr(orR) > "yyy" [orR]
+"OrGateRangedAllFail: -orGateRangedAllFail"
 hcCondCell = [(MkStr(a) > "a" 7)]
 "HcCondCell: -hcCondCell"
 hcCondAndValueCell = [(MkStr(a) > "a" MkStr(b))]

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -518,3 +518,21 @@ chainGateHeap = MkStr(chI) > "s2" < "s8" [chI]
 "ChainGateHeap: -chainGateHeap"
 chainCondValHeap = [(MkStr(chI) > "s2" < "s8"  chI)]
 "ChainCondValHeap: -chainCondValHeap"
+
+# A (cond value) as a bare print/root expression, with no enclosing let. Print
+# statements don't set InValueExpr, so typeCondValueExpr must force the cond into
+# value position itself — otherwise the cond types as a plain boolean and is
+# rejected ("must be a comparison that can fail"). The value prints when the cond
+# holds, 0 when it fails. Regression guard for that flip (scalar + chained).
+rootA = 5
+"RootCondPrintTrue:"
+(rootA > 2  10)
+rootB = 1
+"RootCondPrintFalse:"
+(rootB > 2  10)
+rootC = 5
+"RootChainPrint:"
+(rootC > 2 < 8  rootC * rootC)
+rootD = 1
+"RootChainPrintFalse:"
+(rootD > 2 < 8  rootD * rootD)

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -476,3 +476,12 @@ chainKeep = chB > 2 < 8  chB * chB
 # comma-AND (`i > 2, i < 8`) for a two-sided bound. This documents the behaviour.
 chainLeftmost = [2 < chI < 8]
 "ChainLeftmost: -chainLeftmost"
+
+# Heap operands in a chained comparison: the chain reuses one heap LHS across its
+# links, which must be freed exactly once. (A naive cleanup tracked it per link and
+# double-freed it — a crash.) Works in a gate and a (cond value), over both the
+# admitted (s3..s7) and failing iterations, with no leak.
+chainGateHeap = MkStr(chI) > "s2" < "s8" [chI]
+"ChainGateHeap: -chainGateHeap"
+chainCondValHeap = [(MkStr(chI) > "s2" < "s8"  chI)]
+"ChainCondValHeap: -chainCondValHeap"

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -390,6 +390,17 @@ hcOrFallThrough = (MkStr(a) > "zzz" || MkStr(b) > "a" 7)
 # the gate is false, so the (cond value) resolves to its zero.
 hcOrAllFail = (MkStr(a) > "zzz" || MkStr(b) > "zzz" 7)
 "HcOrAllFail: -hcOrAllFail"
+# || gate short-circuits: a later arm is not evaluated once an earlier one wins.
+# Nothing traps in Pluto, so the observable is the bounds guard — an out-of-bounds
+# read in an arm trips it and skips the cond-value (resolving to zero). arm1 wins
+# => arm2's OOB is NOT evaluated, no trip, gate yields 7; arm1 fails => arm2 IS
+# evaluated, trips, => 0. The 7-vs-0 difference (only arm1's truth changed) proves
+# arm2 is skipped on a win.
+scOob = [1]
+scOrShortCircuit = (1 < 2 || scOob[5] < 5  7)
+"ScOrShortCircuit: -scOrShortCircuit"
+scOrSecondArmRuns = (1 > 2 || scOob[5] < 5  7)
+"ScOrSecondArmRuns: -scOrSecondArmRuns"
 hcCondCell = [(MkStr(a) > "a" 7)]
 "HcCondCell: -hcCondCell"
 hcCondAndValueCell = [(MkStr(a) > "a" MkStr(b))]

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -382,6 +382,14 @@ hcAnded = MkStr(a) > "a", MkStr(b) > "a" 7
 "HcAnded: -hcAnded"
 hcOrShortCircuit = (MkStr(a) > "a" || MkStr(b) > "zzz" 7)
 "HcOrShortCircuit: -hcOrShortCircuit"
+# || gate, fall-through: the first heap arm fails (its LHS must be freed) before a
+# later arm wins.
+hcOrFallThrough = (MkStr(a) > "zzz" || MkStr(b) > "a" 7)
+"HcOrFallThrough: -hcOrFallThrough"
+# || gate, all arms fail: every heap LHS computed for the comparisons is freed and
+# the gate is false, so the (cond value) resolves to its zero.
+hcOrAllFail = (MkStr(a) > "zzz" || MkStr(b) > "zzz" 7)
+"HcOrAllFail: -hcOrAllFail"
 hcCondCell = [(MkStr(a) > "a" 7)]
 "HcCondCell: -hcCondCell"
 hcCondAndValueCell = [(MkStr(a) > "a" MkStr(b))]

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -332,3 +332,37 @@ lorBoundarySkip = 100
 "LogicalOrBoundarySkipBefore: -lorBoundarySkip"
 lorBoundarySkip = 1 > 5 || 2 > 6 33 > 0 || -1
 "LogicalOrBoundarySkipKeepsDefault: -lorBoundarySkip"
+
+# A value-position comparison used as a (scalar) collector cell resolves locally
+# per cell — zero-fill on false, the LHS on true — exactly like the ranged form
+# and like (cond value). It is NOT a gate over the whole literal: a single failed
+# cell does not empty the array or keep the old value, and sibling cells are
+# independent. (Regression: scalar cells used to be lifted into a statement gate,
+# so `[a > 99]` collapsed to `[]` and `[a > 2  a > 99]` to `[]`.)
+scalarCmpCellTrue = [a > 2]
+"ScalarCmpCellTrue: -scalarCmpCellTrue"
+scalarCmpCellFalse = [a > 99]
+"ScalarCmpCellFalse: -scalarCmpCellFalse"
+scalarCmpMulti = [a > 2  a > 99]
+"ScalarCmpMulti: -scalarCmpMulti"
+scalarCmpFb = [a > 99 || -1]
+"ScalarCmpFb: -scalarCmpFb"
+
+# Heap LHS in a scalar comparison cell: the cell value is owned by the array and
+# freed with it, with no leak — on the true arm (value taken) and the false arm
+# (the LHS computed for the comparison is dropped). (Regression: the lifted
+# statement gate double-evaluated the cell and leaked its heap LHS; N heap cells
+# leaked N strings.)
+heapCmpCell = [MkStr(a) > "a"]
+"HeapCmpCell: -heapCmpCell"
+heapCmpFalse = [MkStr(b) > "zzz"]
+"HeapCmpFalse: -heapCmpFalse"
+heapCmpMulti = [MkStr(a) > "a"  MkStr(b) > "a"]
+"HeapCmpMulti: -heapCmpMulti"
+
+# (cond value) || fallback with a heap value as a scalar collector cell: also
+# leak-free on both the value and fallback arms.
+heapCondvalOrTrue = [(a > 2 MkStr(a)) || "def"]
+"HeapCondvalOrTrue: -heapCondvalOrTrue"
+heapCondvalOrFalse = [(b > 2 MkStr(a)) || "def"]
+"HeapCondvalOrFalse: -heapCondvalOrFalse"

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -442,3 +442,10 @@ orWrapHeapCell = [(MkStr(owI) > "s6") ⊕ "!" || "def"]
 # condition, so `[t * t || -1]` has nothing for the || to attach to.
 orWrapRepeatedCond = [(owI > 2 < 8) * (owI > 2 < 8) || -1]
 "OrWrapRepeatedCond: -orWrapRepeatedCond"
+
+# A complicated per-element/piecewise function is one chain of (cond value) || ...
+# || default, evaluated in order with the first matching branch winning — one
+# pass, in order, and length-preserving (no splitting the domain and concatenating
+# filtered pieces). Here: owI < 2 -> -10, else < 5 -> 0, else < 8 -> owI^2, else 999.
+owPiecewise = [(owI < 2 -10) || (owI < 5 0) || (owI < 8 owI * owI) || 999]
+"OwPiecewise: -owPiecewise"

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -434,3 +434,11 @@ orWrapHeapFalse = (MkStr(b) > "s2") ⊕ "!" || "def"
 "OrWrapHeapFalse: -orWrapHeapFalse"
 orWrapHeapCell = [(MkStr(owI) > "s6") ⊕ "!" || "def"]
 "OrWrapHeapCell: -orWrapHeapCell"
+
+# The condition may appear more than once in the left operand; all occurrences
+# are ANDed (here identical, so equivalent to one). This gives integer i^2 (vs
+# the float ^) with a -1 fallback. The condition must stay inline: factoring it
+# into a variable (`t = owI > 2 < 8`) resolves it to a value with no live
+# condition, so `[t * t || -1]` has nothing for the || to attach to.
+orWrapRepeatedCond = [(owI > 2 < 8) * (owI > 2 < 8) || -1]
+"OrWrapRepeatedCond: -orWrapRepeatedCond"

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -366,3 +366,26 @@ heapCondvalOrTrue = [(a > 2 MkStr(a)) || "def"]
 "HeapCondvalOrTrue: -heapCondvalOrTrue"
 heapCondvalOrFalse = [(b > 2 MkStr(a)) || "def"]
 "HeapCondvalOrFalse: -heapCondvalOrFalse"
+
+# Heap operands in CONDITION position: a comparison used only as a boolean (a
+# gate, a (cond value) condition, an || test) still computes its operands, and a
+# heap operand must be freed even though it is never the result — on the true and
+# false arms, on both sides of the comparison, when ANDed, when short-circuited,
+# and per-iteration in a collector. (All leak-checked by the suite.)
+hcCondTrue = (MkStr(a) > "a" 7)
+"HcCondTrue: -hcCondTrue"
+hcCondFalse = (MkStr(a) > "zzz" 7)
+"HcCondFalse: -hcCondFalse"
+hcBothSides = (MkStr(a) > MkStr(b) 7)
+"HcBothSides: -hcBothSides"
+hcAnded = MkStr(a) > "a", MkStr(b) > "a" 7
+"HcAnded: -hcAnded"
+hcOrShortCircuit = (a > 2 || MkStr(b) > "a" 7)
+"HcOrShortCircuit: -hcOrShortCircuit"
+hcCondCell = [(MkStr(a) > "a" 7)]
+"HcCondCell: -hcCondCell"
+hcCondAndValueCell = [(MkStr(a) > "a" MkStr(b))]
+"HcCondAndValueCell: -hcCondAndValueCell"
+hcRng = 0:3
+hcRangedCond = [(MkStr(hcRng) > "s0" hcRng)]
+"HcRangedCond: -hcRangedCond"


### PR DESCRIPTION
## Summary

Adds `(cond value)` — a parenthesized conditional expression that yields `value` when `cond` holds and otherwise resolves **locally to the zero value**. It works anywhere a value is expected: arithmetic operands, call args, and array cells. A trailing `|| fallback` binds *outside* the parens and overrides the zero; inside `[]` a failed cell zero-fills.

```python
x = (a > 2 10)            # 10 when a > 2, else 0
x = (a > 2 10) + 1        # 11 when a > 2, else 1   (local resolution)
x = (a > 2 10) || 7       # 10 when a > 2, else 7   (fallback overrides the zero)
arr = [1 (a > 2 5) 3]     # [1 5 3] when a > 2, else [1 0 3]  (zero-fill)
```

## Design

Local resolution (per [docs/Pluto Conditional Value Semantics.md](docs/Pluto%20Conditional%20Value%20Semantics.md)): `(cond value)` is a self-contained value — `cond ? value : zero` — that composes as a plain operand. Lowered as **branch+phi**, so only the taken arm is evaluated (a heap value or fallback is never allocated on the unused path → leak-safe).

- **ast**: new `CondValueExpr` node, wired into `ExprChildren`/`RewriteExpr`.
- **parser**: `parseGroupedExpression` recognizes `(cond value)` when the first sub-expression is a condition (reuses `isCondition`) and a value follows. Bare `(cond)` and ordinary grouping `(x + 1)` are unchanged; `(cond value) || fb` keeps the `||` outside.
- **solver**: `typeCondValueExpr` types the result as the value's type and marks it `CondValue` (so it gates and can be the failable left operand of a value-position `||`); the condition is validated as a boolean.
- **compiler**: branch+phi lowering, plus a `compileYield` path for the `||` case.

## Transitional inconsistency (documented)

`(cond value)` resolves **locally** to zero, while a bare value-position comparison (`a > 2`) still **propagates** (keep-old). They agree for new variables and inside array cells, and differ only for existing variables and nested arithmetic. The planned follow-up migrates bare comparisons to the same local resolution, removing the inconsistency.

## Validation

- `go test ./ast ./parser ./compiler ./lexer` — green (new parser unit tests for `(cond value)`, fallback, array cell, and the `(cond)`/`(x+1)` regression guards).
- `python3 test.py` — full E2E **60/60**, including the new `tests/cond/cond_value.spt` (scalars, nested arithmetic, fallback, array cells with zero-fill/override, float, and heap-string ownership).
- `python3 test.py tests/cond --leak-check` — no leaks, including the heap-string `(cond value)` arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)