### PR TITLE
feat(compiler): allow conjunction conditions in (cond value) and statement gates

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -481,13 +481,15 @@ func (ie *InfixExpression) String() string {
 	return out.String()
 }
 
-// CondValueExpr is a parenthesized conditional value: (cond value).
-// It yields Value when Cond holds, otherwise nothing (which a boundary
-// resolves to the zero value, or a trailing `|| fallback` overrides).
+// CondValueExpr is a parenthesized conditional value: (cond value). Condition is
+// a list of comparisons ANDed together (mirroring the statement level), so
+// `(a > 2, b > 3  v)` yields Value only when every condition holds, otherwise
+// nothing (which a boundary resolves to the zero value, or a trailing
+// `|| fallback` overrides).
 type CondValueExpr struct {
-	Token token.Token // the '(' token
-	Cond  Expression
-	Value Expression
+	Token     token.Token // the '(' token
+	Condition []Expression
+	Value     Expression
 }
 
 func (cv *CondValueExpr) expressionNode()  {}
@@ -495,7 +497,7 @@ func (cv *CondValueExpr) Tok() token.Token { return cv.Token }
 func (cv *CondValueExpr) String() string {
 	var out bytes.Buffer
 	out.WriteString("(")
-	out.WriteString(cv.Cond.String())
+	out.WriteString(printVec(cv.Condition))
 	out.WriteString(" ")
 	out.WriteString(cv.Value.String())
 	out.WriteString(")")
@@ -560,7 +562,7 @@ func ExprChildren(expr Expression) []Expression {
 	case *InfixExpression:
 		return []Expression{e.Left, e.Right}
 	case *CondValueExpr:
-		return []Expression{e.Cond, e.Value}
+		return append(append([]Expression(nil), e.Condition...), e.Value)
 	case *PrefixExpression:
 		return []Expression{e.Right}
 	case *CallExpression:
@@ -605,15 +607,22 @@ func RewriteExpr(expr Expression, rewrite func(Expression) Expression) Expressio
 			Right:    right,
 		}
 	case *CondValueExpr:
-		cond := rewrite(e.Cond)
+		changed := false
+		conds := make([]Expression, len(e.Condition))
+		for i, c := range e.Condition {
+			conds[i] = rewrite(c)
+			if conds[i] != c {
+				changed = true
+			}
+		}
 		value := rewrite(e.Value)
-		if cond == e.Cond && value == e.Value {
+		if !changed && value == e.Value {
 			return expr
 		}
 		return &CondValueExpr{
-			Token: e.Token,
-			Cond:  cond,
-			Value: value,
+			Token:     e.Token,
+			Condition: conds,
+			Value:     value,
 		}
 	case *PrefixExpression:
 		right := rewrite(e.Right)

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -481,15 +481,15 @@ func (ie *InfixExpression) String() string {
 	return out.String()
 }
 
-// CondValueExpr is a parenthesized conditional value: (cond value). Condition is
+// CondValueExpr is a parenthesized conditional value: (cond value). Conds is
 // a list of comparisons ANDed together (mirroring the statement level), so
 // `(a > 2, b > 3  v)` yields Value only when every condition holds, otherwise
 // nothing (which a boundary resolves to the zero value, or a trailing
 // `|| fallback` overrides).
 type CondValueExpr struct {
-	Token     token.Token // the '(' token
-	Condition []Expression
-	Value     Expression
+	Token token.Token // the '(' token
+	Conds []Expression
+	Value Expression
 }
 
 func (cv *CondValueExpr) expressionNode()  {}
@@ -497,7 +497,7 @@ func (cv *CondValueExpr) Tok() token.Token { return cv.Token }
 func (cv *CondValueExpr) String() string {
 	var out bytes.Buffer
 	out.WriteString("(")
-	out.WriteString(printVec(cv.Condition))
+	out.WriteString(printVec(cv.Conds))
 	out.WriteString(" ")
 	out.WriteString(cv.Value.String())
 	out.WriteString(")")
@@ -562,7 +562,7 @@ func ExprChildren(expr Expression) []Expression {
 	case *InfixExpression:
 		return []Expression{e.Left, e.Right}
 	case *CondValueExpr:
-		return append(append([]Expression(nil), e.Condition...), e.Value)
+		return append(append([]Expression(nil), e.Conds...), e.Value)
 	case *PrefixExpression:
 		return []Expression{e.Right}
 	case *CallExpression:
@@ -608,8 +608,8 @@ func RewriteExpr(expr Expression, rewrite func(Expression) Expression) Expressio
 		}
 	case *CondValueExpr:
 		changed := false
-		conds := make([]Expression, len(e.Condition))
-		for i, c := range e.Condition {
+		conds := make([]Expression, len(e.Conds))
+		for i, c := range e.Conds {
 			conds[i] = rewrite(c)
 			if conds[i] != c {
 				changed = true
@@ -620,9 +620,9 @@ func RewriteExpr(expr Expression, rewrite func(Expression) Expression) Expressio
 			return expr
 		}
 		return &CondValueExpr{
-			Token:     e.Token,
-			Condition: conds,
-			Value:     value,
+			Token: e.Token,
+			Conds: conds,
+			Value: value,
 		}
 	case *PrefixExpression:
 		right := rewrite(e.Right)

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -665,7 +665,7 @@ func (c *Compiler) compileYield(expr ast.Expression, baseCond llvm.Value, onTrue
 	// A (cond value) yields its value only when its condition holds; otherwise it
 	// fails to onFalse (so an enclosing || tries the next alternative).
 	if cv, ok := expr.(*ast.CondValueExpr); ok {
-		cond := c.andGates(cv.Condition)
+		cond := c.andGates(cv.Conds)
 		if !baseCond.IsNil() {
 			cond = c.builder.CreateAnd(baseCond, cond, "cv_and")
 		}
@@ -734,7 +734,7 @@ func (c *Compiler) compileCondValueExpr(expr *ast.CondValueExpr) []*Symbol {
 func (c *Compiler) compileCondValueExprBasic(expr *ast.CondValueExpr, info *ExprInfo) []*Symbol {
 	outTypes := info.OutTypes
 
-	cond := c.andGates(expr.Condition)
+	cond := c.andGates(expr.Conds)
 	trueBlock, falseBlock, contBlock := c.createIfElseCont(cond, "cv_true", "cv_false", "cv_cont")
 
 	// True path evaluates the value (one symbol per output slot for a

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -50,14 +50,11 @@ func (c *Compiler) compileGate(expr ast.Expression) llvm.Value {
 	return c.createLoad(gatePtr, i1, "gate")
 }
 
-// evalConditions ANDs the i1 gates of a list of condition expressions and folds
-// in the bounds-guard check. The caller must pushBoundsGuard before and
-// popBoundsGuard after.
-func (c *Compiler) evalConditions(exprs []ast.Expression, guardPtr llvm.Value) llvm.Value {
-	// Every condition reaching evalConditions is a comparison: validation rejects
-	// non-comparison gates, and splitCondRanges routes bare range drivers into the
-	// range list rather than here. So compileGate returns a non-nil gate for each,
-	// and since callers pass a non-empty list, cond is non-nil after the loop.
+// andGates ANDs the i1 gates of a list of condition expressions ("did every
+// condition yield?"). Callers pass a non-empty list of comparisons, so each
+// compileGate returns a non-nil gate and the result is non-nil. Bounds-guard
+// folding is the caller's concern (only the statement path needs it).
+func (c *Compiler) andGates(exprs []ast.Expression) llvm.Value {
 	var cond llvm.Value
 	for _, expr := range exprs {
 		gate := c.compileGate(expr)
@@ -67,6 +64,18 @@ func (c *Compiler) evalConditions(exprs []ast.Expression, guardPtr llvm.Value) l
 			cond = c.builder.CreateAnd(cond, gate, "and_cond")
 		}
 	}
+	return cond
+}
+
+// evalConditions ANDs the i1 gates of a list of condition expressions and folds
+// in the bounds-guard check. The caller must pushBoundsGuard before and
+// popBoundsGuard after.
+func (c *Compiler) evalConditions(exprs []ast.Expression, guardPtr llvm.Value) llvm.Value {
+	// Every condition reaching evalConditions is a comparison: validation rejects
+	// non-comparison gates, and splitCondRanges routes bare range drivers into the
+	// range list rather than here. So compileGate returns a non-nil gate for each,
+	// and since callers pass a non-empty list, cond is non-nil after the loop.
+	cond := c.andGates(exprs)
 
 	if c.stmtBoundsUsed() {
 		boundsOK := c.createLoad(guardPtr, Int{Width: 1}, "cond_bounds_ok")
@@ -656,7 +665,7 @@ func (c *Compiler) compileYield(expr ast.Expression, baseCond llvm.Value, onTrue
 	// A (cond value) yields its value only when its condition holds; otherwise it
 	// fails to onFalse (so an enclosing || tries the next alternative).
 	if cv, ok := expr.(*ast.CondValueExpr); ok {
-		cond := c.compileGate(cv.Cond)
+		cond := c.andGates(cv.Condition)
 		if !baseCond.IsNil() {
 			cond = c.builder.CreateAnd(baseCond, cond, "cv_and")
 		}
@@ -719,13 +728,13 @@ func (c *Compiler) compileCondValueExpr(expr *ast.CondValueExpr) []*Symbol {
 	return c.compileCondValueExprBasic(expr, info)
 }
 
-// compileCondValueExprBasic is the scalar lowering: yield Value when Cond holds,
-// otherwise the zero of each output slot's type. Only the taken arm is
-// evaluated, so a heap value is never allocated on the path it isn't used.
+// compileCondValueExprBasic is the scalar lowering: yield Value when every
+// condition holds, otherwise the zero of each output slot's type. Only the taken
+// arm is evaluated, so a heap value is never allocated on the path it isn't used.
 func (c *Compiler) compileCondValueExprBasic(expr *ast.CondValueExpr, info *ExprInfo) []*Symbol {
 	outTypes := info.OutTypes
 
-	cond := c.compileGate(expr.Cond)
+	cond := c.andGates(expr.Condition)
 	trueBlock, falseBlock, contBlock := c.createIfElseCont(cond, "cv_true", "cv_false", "cv_cont")
 
 	// True path evaluates the value (one symbol per output slot for a

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -482,15 +482,24 @@ func (ts *TypeSolver) HandleArrayRangeExpression(ar *ast.ArrayRangeExpression) (
 // HandleInfixRanges processes infix expressions, recursively handling both operands
 // and tracking whether each side contains ranges for optimization decisions.
 func (ts *TypeSolver) HandleCondValueRanges(cv *ast.CondValueExpr) (ranges []*RangeInfo, rew ast.Expression) {
-	condRanges, cond := ts.HandleRanges(cv.Cond)
+	changed := false
+	conds := make([]ast.Expression, len(cv.Condition))
+	for i, c := range cv.Condition {
+		var cRanges []*RangeInfo
+		cRanges, conds[i] = ts.HandleRanges(c)
+		ranges = mergeUses(ranges, cRanges)
+		if conds[i] != c {
+			changed = true
+		}
+	}
 	valRanges, val := ts.HandleRanges(cv.Value)
-	ranges = mergeUses(condRanges, valRanges)
+	ranges = mergeUses(ranges, valRanges)
 
-	if cond == cv.Cond && val == cv.Value {
+	if !changed && val == cv.Value {
 		rew = cv
 	} else {
 		cp := *cv
-		cp.Cond, cp.Value = cond, val
+		cp.Condition, cp.Value = conds, val
 		rew = &cp
 		// Cache entry for the rewritten node: operands are scalarized iterators.
 		originalInfo := ts.ExprCache[key(ts.FuncNameMangled, cv)]
@@ -762,19 +771,16 @@ func (ts *TypeSolver) conditionCanFail(expr ast.Expression) bool {
 }
 
 func (ts *TypeSolver) validateStatementCondition(expr ast.Expression, condTypes []Type) {
-	if len(condTypes) != 1 {
-		ts.Errors = append(ts.Errors, &token.CompileError{
-			Token: expr.Tok(),
-			Msg:   fmt.Sprintf("statement condition must produce a single value, got %d", len(condTypes)),
-		})
+	// Defer until the operand types resolve (an unresolved cell may still become a
+	// comparison during fixpoint iteration).
+	if !typesResolved(condTypes) {
 		return
 	}
 
+	// A multi-cell comparison (Pair > Pair) gates on the cell-wise conjunction,
+	// like a single comparison; it is accepted by the conditionCanFail check
+	// below. The scalar/array and range-driver checks inspect the first cell.
 	condType := condTypes[0]
-	if condType.Kind() == UnresolvedKind {
-		return
-	}
-
 	if condType.Kind() == ArrayKind {
 		ts.Errors = append(ts.Errors, &token.CompileError{
 			Token: expr.Tok(),
@@ -1561,33 +1567,58 @@ func (ts *TypeSolver) logicalOrValueType(leftType, rightType Type, tok token.Tok
 	}
 }
 
+// typesResolved reports whether a slice is non-empty and every type in it is
+// resolved. Used to defer condition diagnostics until operand types settle
+// during fixpoint iteration (an unresolved cell may still become a comparison).
+func typesResolved(types []Type) bool {
+	if len(types) == 0 {
+		return false
+	}
+	for _, t := range types {
+		if t.Kind() == UnresolvedKind {
+			return false
+		}
+	}
+	return true
+}
+
 // typeCondValueExpr types a parenthesized conditional value (cond value).
-// The condition is typed in value context (like a statement gate): a comparison
-// yields its LHS and chains (so `(i > 2 < 8  v)` works), and it gates on whether
-// that value-position expression yields — so it must be able to fail. The result
-// type is the value's type. Slots are marked CondValue so the value gates on
+// The conditions are typed in value context (like a statement gate): a comparison
+// yields its LHS and chains (so `(i > 2 < 8  v)` works), and each gates on whether
+// that value-position expression yields — so it must be able to fail. Multiple
+// comma-separated conditions are ANDed (the value yields only when all hold). The
+// result type is the value's type. Slots are marked CondValue so the value gates on
 // lowering and the node can serve as the (failable) left operand of a value-position ||.
 func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []Type {
-	// A (cond value)'s condition and value are intrinsically value positions
+	// A (cond value)'s conditions and value are intrinsically value positions
 	// (comparisons yield their LHS and chain), independent of the surrounding
-	// statement: the cond IS a gate by construction. A print/root expression
+	// statement: each condition IS a gate by construction. A print/root expression
 	// statement does not set InValueExpr, so force it here (and restore on return)
 	// rather than relying on the enclosing context.
 	savedInValueExpr := ts.InValueExpr
 	ts.InValueExpr = true
 	defer func() { ts.InValueExpr = savedInValueExpr }()
-	condTypes := ts.TypeExpression(expr.Cond, true)
 
-	if len(condTypes) != 1 {
-		ts.Errors = append(ts.Errors, &token.CompileError{
-			Token: expr.Token,
-			Msg:   fmt.Sprintf("(cond value) condition must produce a single value, got %d", len(condTypes)),
-		})
-	} else if condTypes[0].Kind() != UnresolvedKind && !ts.conditionCanFail(expr.Cond) {
-		ts.Errors = append(ts.Errors, &token.CompileError{
-			Token: expr.Token,
-			Msg:   fmt.Sprintf("(cond value) condition must be a comparison that can fail, got %s", condTypes[0]),
-		})
+	// Each condition is typed and validated independently; the gate is the
+	// conjunction of them all (the value yields only when every condition holds),
+	// mirroring the statement level. A condition must be a comparison that can
+	// fail — a multi-cell comparison (Pair > Pair, or a string pair) is fine: it
+	// AND-reduces cell-wise at lowering, so the gate holds only when every cell
+	// does. A bare identifier or always-yielding || cannot gate. The check is
+	// deferred until the operand types resolve, so a not-yet-typed operand does
+	// not trip a spurious diagnostic during fixpoint iteration.
+	condHasRanges := false
+	for _, cond := range expr.Condition {
+		condTypes := ts.TypeExpression(cond, true)
+		if typesResolved(condTypes) && !ts.conditionCanFail(cond) {
+			ts.Errors = append(ts.Errors, &token.CompileError{
+				Token: cond.Tok(),
+				Msg:   fmt.Sprintf("(cond value) condition must be a comparison that can fail, got %s", condTypes[0]),
+			})
+		}
+		if info := ts.ExprCache[key(ts.FuncNameMangled, cond)]; info != nil && info.HasRanges {
+			condHasRanges = true
+		}
 	}
 
 	// The value is always a nested, per-iteration value (the CondValueExpr or its
@@ -1595,7 +1626,6 @@ func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []
 	// resolves to its iterator type, not a Range.
 	valueTypes := ts.TypeExpression(expr.Value, false)
 
-	condInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Cond)]
 	valInfo := ts.ExprCache[key(ts.FuncNameMangled, expr.Value)]
 
 	types := make([]Type, len(valueTypes))
@@ -1608,7 +1638,7 @@ func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []
 	ts.ExprCache[key(ts.FuncNameMangled, expr)] = &ExprInfo{
 		OutTypes:     types,
 		ExprLen:      len(types),
-		HasRanges:    (condInfo != nil && condInfo.HasRanges) || (valInfo != nil && valInfo.HasRanges),
+		HasRanges:    condHasRanges || (valInfo != nil && valInfo.HasRanges),
 		CompareModes: compareModes,
 	}
 	return types

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -483,8 +483,8 @@ func (ts *TypeSolver) HandleArrayRangeExpression(ar *ast.ArrayRangeExpression) (
 // and tracking whether each side contains ranges for optimization decisions.
 func (ts *TypeSolver) HandleCondValueRanges(cv *ast.CondValueExpr) (ranges []*RangeInfo, rew ast.Expression) {
 	changed := false
-	conds := make([]ast.Expression, len(cv.Condition))
-	for i, c := range cv.Condition {
+	conds := make([]ast.Expression, len(cv.Conds))
+	for i, c := range cv.Conds {
 		var cRanges []*RangeInfo
 		cRanges, conds[i] = ts.HandleRanges(c)
 		ranges = mergeUses(ranges, cRanges)
@@ -499,7 +499,7 @@ func (ts *TypeSolver) HandleCondValueRanges(cv *ast.CondValueExpr) (ranges []*Ra
 		rew = cv
 	} else {
 		cp := *cv
-		cp.Condition, cp.Value = conds, val
+		cp.Conds, cp.Value = conds, val
 		rew = &cp
 		// Cache entry for the rewritten node: operands are scalarized iterators.
 		originalInfo := ts.ExprCache[key(ts.FuncNameMangled, cv)]
@@ -1608,7 +1608,7 @@ func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []
 	// deferred until the operand types resolve, so a not-yet-typed operand does
 	// not trip a spurious diagnostic during fixpoint iteration.
 	condHasRanges := false
-	for _, cond := range expr.Condition {
+	for _, cond := range expr.Conds {
 		condTypes := ts.TypeExpression(cond, true)
 		if typesResolved(condTypes) && !ts.conditionCanFail(cond) {
 			ts.Errors = append(ts.Errors, &token.CompileError{

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -779,9 +779,11 @@ func (ts *TypeSolver) validateStatementCondition(expr ast.Expression, condTypes 
 
 	// A multi-cell comparison (Pair > Pair) gates on the cell-wise conjunction,
 	// like a single comparison; it is accepted by the conditionCanFail check
-	// below. The scalar/array and range-driver checks inspect the first cell.
+	// below. Every cell must be a scalar: an array cell is a filter, which gate
+	// lowering would silently drop (it ANDs only scalar cells), so reject a
+	// condition with any array cell — not just the first.
 	condType := condTypes[0]
-	if condType.Kind() == ArrayKind {
+	if anyArrayCell(condTypes) {
 		ts.Errors = append(ts.Errors, &token.CompileError{
 			Token: expr.Tok(),
 			Msg:   "statement condition must produce a scalar value, not an array",
@@ -1582,6 +1584,22 @@ func typesResolved(types []Type) bool {
 	return true
 }
 
+// anyArrayCell reports whether any cell of a value-position condition is an array.
+// A gate is the cell-wise conjunction of scalar comparisons; an array comparison
+// is a filter (it yields an array, not a boolean), so gate lowering only ANDs the
+// scalar cells and silently drops an array cell. A gate condition must therefore
+// have no array cell — checked across every cell, not just the first, so a mixed
+// scalar/array multi-return comparison (Pair > Pair where one slot is an array)
+// is rejected. Shared by statement gates and (cond value) conditions.
+func anyArrayCell(condTypes []Type) bool {
+	for _, t := range condTypes {
+		if t.Kind() == ArrayKind {
+			return true
+		}
+	}
+	return false
+}
+
 // typeCondValueExpr types a parenthesized conditional value (cond value).
 // The conditions are typed in value context (like a statement gate): a comparison
 // yields its LHS and chains (so `(i > 2 < 8  v)` works), and each gates on whether
@@ -1610,11 +1628,20 @@ func (ts *TypeSolver) typeCondValueExpr(expr *ast.CondValueExpr, isRoot bool) []
 	condHasRanges := false
 	for _, cond := range expr.Conds {
 		condTypes := ts.TypeExpression(cond, true)
-		if typesResolved(condTypes) && !ts.conditionCanFail(cond) {
-			ts.Errors = append(ts.Errors, &token.CompileError{
-				Token: cond.Tok(),
-				Msg:   fmt.Sprintf("(cond value) condition must be a comparison that can fail, got %s", condTypes[0]),
-			})
+		if typesResolved(condTypes) {
+			if anyArrayCell(condTypes) {
+				// An array cell is a filter, not a scalar boolean; gate lowering
+				// would silently drop it (see anyArrayCell), so reject it here too.
+				ts.Errors = append(ts.Errors, &token.CompileError{
+					Token: cond.Tok(),
+					Msg:   "(cond value) condition must produce a scalar value, not an array",
+				})
+			} else if !ts.conditionCanFail(cond) {
+				ts.Errors = append(ts.Errors, &token.CompileError{
+					Token: cond.Tok(),
+					Msg:   fmt.Sprintf("(cond value) condition must be a comparison that can fail, got %s", condTypes[0]),
+				})
+			}
 		}
 		if info := ts.ExprCache[key(ts.FuncNameMangled, cond)]; info != nil && info.HasRanges {
 			condHasRanges = true

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -528,6 +528,35 @@ func TestArrayConditionEmitsSingleDiagnostic(t *testing.T) {
 	require.Contains(t, ts.Errors[0].Msg, "statement condition must produce a scalar value, not an array")
 }
 
+func TestMixedArrayScalarStatementConditionRejected(t *testing.T) {
+	ctx := llvm.NewContext()
+	// MixSA returns (scalar, array); the array cell is the second slot, so the
+	// gate's array cell is caught only by checking every cell, not just the first.
+	// Such a gate would otherwise silently drop the array comparison at lowering.
+	code := "s, arr = MixSA(x)\n    s = x\n    arr = [x x + 1]"
+	cc := NewCodeCompiler(ctx, "mixedArrayStmtCond", "", mustParseCode(t, code))
+	require.Empty(t, cc.Compile())
+
+	script := "y = MixSA(5) > MixSA(3)  100"
+	sl := lexer.New("mixedArrayStmtCond.spt", script)
+	sp := parser.NewScriptParser(sl)
+	program := sp.Parse()
+	require.Empty(t, sp.Errors(), "unexpected parse errors: %v", sp.Errors())
+
+	sc := NewScriptCompiler(ctx, program, cc, make(map[string]*Func), make(map[ExprKey]*ExprInfo))
+	ts := NewTypeSolver(sc)
+	ts.Solve()
+
+	found := false
+	for _, err := range ts.Errors {
+		if strings.Contains(err.Msg, "statement condition must produce a scalar value, not an array") {
+			found = true
+			break
+		}
+	}
+	require.Truef(t, found, "expected array-cell rejection, got: %v", ts.Errors)
+}
+
 func TestScalarConditionEmitsTypeDiagnostic(t *testing.T) {
 	ctx := llvm.NewContext()
 	cc := NewCodeCompiler(ctx, "scalarConditionDiagnostic", "", ast.NewCode())
@@ -583,6 +612,16 @@ func TestCondValueDiagnostics(t *testing.T) {
 			name:        "ConjunctIdentifierNotComparison",
 			script:      "a = 5\nn = 1\nx = (a > 2, n  7)",
 			expectError: "(cond value) condition must be a comparison that can fail",
+		},
+		{
+			// A mixed scalar/array multi-return comparison cannot gate: the array
+			// cell is a filter, not a boolean, and gate lowering would silently drop
+			// it. MixSA returns (scalar, array) so the array cell is not first —
+			// exercising the all-cells check, not just cell 0.
+			name:        "MixedArrayCellRejected",
+			code:        "s, arr = MixSA(x)\n    s = x\n    arr = [x x + 1]",
+			script:      "y = (MixSA(5) > MixSA(3)  7)",
+			expectError: "(cond value) condition must produce a scalar value, not an array",
 		},
 	}
 

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -571,12 +571,18 @@ func TestCondValueDiagnostics(t *testing.T) {
 			expectError: "logical OR value operands must have matching output types, got I64 and Str",
 		},
 		{
-			// A multi-return comparison (Pair > Pair yields two values) cannot be a
-			// (cond value) condition — the gate must be a single value.
-			name:        "ConditionMustProduceSingleValue",
-			code:        "a, b = Pair(x, y)\n    a, b = x, y",
-			script:      "p, q = (Pair(1, 2) > Pair(3, 4)  7)",
-			expectError: "(cond value) condition must produce a single value",
+			// Each conjunct must be able to fail: an always-yielding || fallback
+			// (a > 0 || a always yields) cannot gate, so it is rejected in the list.
+			name:        "ConjunctMustBeFailable",
+			script:      "a = 1\nb = 2\nx = (a > 0 || a, b > 0  7)",
+			expectError: "(cond value) condition must be a comparison that can fail",
+		},
+		{
+			// A bare identifier conjunct is not a comparison, so it cannot gate even
+			// alongside a well-formed comparison.
+			name:        "ConjunctIdentifierNotComparison",
+			script:      "a = 5\nn = 1\nx = (a > 2, n  7)",
+			expectError: "(cond value) condition must be a comparison that can fail",
 		},
 	}
 

--- a/docs/Pluto Conditional Value Semantics.md
+++ b/docs/Pluto Conditional Value Semantics.md
@@ -30,7 +30,10 @@ old = b > 2  x * 3    # b <= 2 -> old stays 99
 new = b > 2  x * 3    # b <= 2 -> new = 0
 ```
 
-Multiple conditions separated by commas are ANDed; all must hold.
+Multiple conditions separated by commas are ANDed; all must hold. A multi-cell
+comparison (`Pair > Pair`, including string pairs) likewise gates on the
+conjunction of its cells — every cell must hold. Both forms work in any condition
+slot (statement gate, `(cond value)`, array cell).
 
 ### Conditions are value positions
 
@@ -191,6 +194,10 @@ them. See [Pluto Range Semantics](Pluto%20Range%20Semantics.md).
   array filters; the parenthesized `(cond value)` expression (local resolution to
   zero, with `|| fallback` and array-cell zero-fill), including per-cell use
   inside array literals.
+- **Conjunction conditions:** every condition slot accepts a comma-AND list
+  (`a > 2, b > 3`) and a multi-cell comparison (`Pair(1, 2) > Pair(0, 1)`, gating
+  on the cell-wise AND — every cell must hold). Heap operands (e.g. string cells
+  via `⊕`) are freed after gating.
 - **Transitional inconsistency:** `(cond value)` resolves **locally** to zero,
   but a bare value-position comparison (`a > 2`) still **propagates** (keep-old).
   So `(a > 2 10) + 1` is `1` when `a <= 2` (local zero), while `(a > 2) + 1`

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1310,7 +1310,7 @@ func (p *StmtParser) parseGroupedExpression() ast.Expression {
 	if !p.expectPeek(token.RPAREN) {
 		return nil
 	}
-	return &ast.CondValueExpr{Token: lparen, Condition: conditions, Value: value}
+	return &ast.CondValueExpr{Token: lparen, Conds: conditions, Value: value}
 }
 
 // assumes current token is token.NEWLINE

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1259,27 +1259,58 @@ func (p *StmtParser) parseGroupedExpression() ast.Expression {
 		return nil
 	}
 
-	// (cond value): a parenthesized conditional value. Recognized when the first
-	// sub-expression is a condition and a value follows before the ')'. A bare
-	// `(cond)` (no value) stays an ordinary value-position expression, and a
-	// trailing `|| fallback` binds outside the parens as a normal infix.
-	if p.isCondition(exp) && !p.peekTokenIs(token.RPAREN) {
+	// Plain grouping: a single sub-expression closed by ')'. A bare `(cond)`
+	// (no value) stays an ordinary value-position expression, and a trailing
+	// `|| fallback` binds outside the parens as a normal infix.
+	if p.peekTokenIs(token.RPAREN) {
 		p.nextToken()
-		value := p.parseExpression(LOWEST, prefixSplitNone)
-		if value == nil {
-			return nil
-		}
+		return exp
+	}
+
+	// (cond value): one or more comma-separated conditions followed by a
+	// space-separated value, mirroring the statement level (conditions are
+	// ANDed). The leading sub-expression must be a condition for this to be a
+	// (cond value); otherwise let expectPeek report the unexpected token.
+	if !p.isCondition(exp) {
 		if !p.expectPeek(token.RPAREN) {
 			return nil
 		}
-		return &ast.CondValueExpr{Token: lparen, Cond: exp, Value: value}
+		return exp
 	}
 
-	if !p.expectPeek(token.RPAREN) {
+	conditions := []ast.Expression{exp}
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken() // consume the previous condition's final token
+		p.nextToken() // move onto the next condition's first token
+		cond := p.parseExpression(LOWEST, prefixSplitAfterCondition)
+		if cond == nil {
+			return nil
+		}
+		conditions = append(conditions, cond)
+	}
+	if !p.conditionsOk(conditions) {
 		return nil
 	}
 
-	return exp
+	// A condition list with no value is incomplete: `(a > 2, b > 3)` has nothing
+	// to yield. (A single `(cond)` is handled above as plain grouping.)
+	if p.peekTokenIs(token.RPAREN) {
+		p.errors = append(p.errors, &token.CompileError{
+			Token: lparen,
+			Msg:   "(cond value) requires a value after the condition(s)",
+		})
+		return nil
+	}
+
+	p.nextToken()
+	value := p.parseExpression(LOWEST, prefixSplitNone)
+	if value == nil {
+		return nil
+	}
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
+	return &ast.CondValueExpr{Token: lparen, Condition: conditions, Value: value}
 }
 
 // assumes current token is token.NEWLINE

--- a/parser/scriptparser_test.go
+++ b/parser/scriptparser_test.go
@@ -910,8 +910,8 @@ func TestCondValueExpr(t *testing.T) {
 	require.Len(t, stmt.Value, 1, "expected one value")
 	cv, ok := stmt.Value[0].(*ast.CondValueExpr)
 	require.Truef(t, ok, "expected *ast.CondValueExpr, got %T", stmt.Value[0])
-	require.Len(t, cv.Condition, 1, "expected one condition")
-	require.Truef(t, testInfixExpression(t, cv.Condition[0], "a", ">", 2), "cond mismatch")
+	require.Len(t, cv.Conds, 1, "expected one condition")
+	require.Truef(t, testInfixExpression(t, cv.Conds[0], "a", ">", 2), "cond mismatch")
 	require.Truef(t, testIntegerLiteral(t, cv.Value, 10), "value mismatch")
 }
 
@@ -927,10 +927,10 @@ func TestCondValueExprConjunction(t *testing.T) {
 	require.Len(t, stmt.Value, 1, "expected one value")
 	cv, ok := stmt.Value[0].(*ast.CondValueExpr)
 	require.Truef(t, ok, "expected *ast.CondValueExpr, got %T", stmt.Value[0])
-	require.Len(t, cv.Condition, 3, "expected three conditions")
-	require.Truef(t, testInfixExpression(t, cv.Condition[0], "a", ">", 2), "cond[0] mismatch")
-	require.Truef(t, testInfixExpression(t, cv.Condition[1], "b", ">", 3), "cond[1] mismatch")
-	require.Truef(t, testInfixExpression(t, cv.Condition[2], "c", "<", 9), "cond[2] mismatch")
+	require.Len(t, cv.Conds, 3, "expected three conditions")
+	require.Truef(t, testInfixExpression(t, cv.Conds[0], "a", ">", 2), "cond[0] mismatch")
+	require.Truef(t, testInfixExpression(t, cv.Conds[1], "b", ">", 3), "cond[1] mismatch")
+	require.Truef(t, testInfixExpression(t, cv.Conds[2], "c", "<", 9), "cond[2] mismatch")
 	require.Truef(t, testIntegerLiteral(t, cv.Value, 10), "value mismatch")
 }
 
@@ -958,7 +958,7 @@ func TestCondValueExprWithFallback(t *testing.T) {
 	require.Equal(t, "||", or.Operator)
 	cv, ok := or.Left.(*ast.CondValueExpr)
 	require.Truef(t, ok, "expected CondValueExpr on the left of ||, got %T", or.Left)
-	require.Truef(t, testInfixExpression(t, cv.Condition[0], "a", ">", 2), "cond mismatch")
+	require.Truef(t, testInfixExpression(t, cv.Conds[0], "a", ">", 2), "cond mismatch")
 	require.Truef(t, testIntegerLiteral(t, cv.Value, 10), "value mismatch")
 	require.Truef(t, testIntegerLiteral(t, or.Right, 7), "fallback mismatch")
 }
@@ -977,7 +977,7 @@ func TestCondValueExprInArray(t *testing.T) {
 	require.Len(t, arr.Rows[0], 3, "expected three cells")
 	cv, ok := arr.Rows[0][1].(*ast.CondValueExpr)
 	require.Truef(t, ok, "expected CondValueExpr cell, got %T", arr.Rows[0][1])
-	require.Truef(t, testInfixExpression(t, cv.Condition[0], "a", ">", 2), "cell cond mismatch")
+	require.Truef(t, testInfixExpression(t, cv.Conds[0], "a", ">", 2), "cell cond mismatch")
 	require.Truef(t, testIntegerLiteral(t, cv.Value, 5), "cell value mismatch")
 }
 
@@ -1035,7 +1035,7 @@ func TestCondValueAttachedPrefixSharedDetection(t *testing.T) {
 	require.Len(t, stmt.Value, 1, "expected one value")
 	cv, ok := stmt.Value[0].(*ast.CondValueExpr)
 	require.Truef(t, ok, "expected *ast.CondValueExpr, got %T", stmt.Value[0])
-	require.Truef(t, testInfixExpression(t, cv.Condition[0], "a", ">", 2), "cond mismatch")
+	require.Truef(t, testInfixExpression(t, cv.Conds[0], "a", ">", 2), "cond mismatch")
 	pre, ok := cv.Value.(*ast.PrefixExpression)
 	require.Truef(t, ok, "expected prefix value, got %T", cv.Value)
 	require.Equal(t, "-", pre.Operator)

--- a/parser/scriptparser_test.go
+++ b/parser/scriptparser_test.go
@@ -910,8 +910,38 @@ func TestCondValueExpr(t *testing.T) {
 	require.Len(t, stmt.Value, 1, "expected one value")
 	cv, ok := stmt.Value[0].(*ast.CondValueExpr)
 	require.Truef(t, ok, "expected *ast.CondValueExpr, got %T", stmt.Value[0])
-	require.Truef(t, testInfixExpression(t, cv.Cond, "a", ">", 2), "cond mismatch")
+	require.Len(t, cv.Condition, 1, "expected one condition")
+	require.Truef(t, testInfixExpression(t, cv.Condition[0], "a", ">", 2), "cond mismatch")
 	require.Truef(t, testIntegerLiteral(t, cv.Value, 10), "value mismatch")
+}
+
+func TestCondValueExprConjunction(t *testing.T) {
+	// Comma-separated conditions are gathered into the Condition list (ANDed),
+	// mirroring the statement level; the value follows the last condition.
+	const input = "x = (a > 2, b > 3, c < 9 10)"
+	sp := NewScriptParser(lexer.New("TestCondValueExprConjunction", input))
+	program := sp.Parse()
+	require.Emptyf(t, sp.Errors(), "unexpected errors: %v", sp.Errors())
+
+	stmt := requireOnlyLetStmt(t, program)
+	require.Len(t, stmt.Value, 1, "expected one value")
+	cv, ok := stmt.Value[0].(*ast.CondValueExpr)
+	require.Truef(t, ok, "expected *ast.CondValueExpr, got %T", stmt.Value[0])
+	require.Len(t, cv.Condition, 3, "expected three conditions")
+	require.Truef(t, testInfixExpression(t, cv.Condition[0], "a", ">", 2), "cond[0] mismatch")
+	require.Truef(t, testInfixExpression(t, cv.Condition[1], "b", ">", 3), "cond[1] mismatch")
+	require.Truef(t, testInfixExpression(t, cv.Condition[2], "c", "<", 9), "cond[2] mismatch")
+	require.Truef(t, testIntegerLiteral(t, cv.Value, 10), "value mismatch")
+}
+
+func TestCondValueConjunctionRequiresValue(t *testing.T) {
+	// A comma-separated condition list with no value is incomplete (a single
+	// `(cond)` stays plain grouping, but `(cond, cond)` has nothing to yield).
+	const input = "x = (a > 2, b > 3)"
+	sp := NewScriptParser(lexer.New("TestCondValueConjunctionRequiresValue", input))
+	sp.Parse()
+	require.NotEmpty(t, sp.Errors(), "expected a parse error for a value-less condition list")
+	require.Contains(t, sp.Errors()[0], "(cond value) requires a value")
 }
 
 func TestCondValueExprWithFallback(t *testing.T) {
@@ -928,7 +958,7 @@ func TestCondValueExprWithFallback(t *testing.T) {
 	require.Equal(t, "||", or.Operator)
 	cv, ok := or.Left.(*ast.CondValueExpr)
 	require.Truef(t, ok, "expected CondValueExpr on the left of ||, got %T", or.Left)
-	require.Truef(t, testInfixExpression(t, cv.Cond, "a", ">", 2), "cond mismatch")
+	require.Truef(t, testInfixExpression(t, cv.Condition[0], "a", ">", 2), "cond mismatch")
 	require.Truef(t, testIntegerLiteral(t, cv.Value, 10), "value mismatch")
 	require.Truef(t, testIntegerLiteral(t, or.Right, 7), "fallback mismatch")
 }
@@ -947,7 +977,7 @@ func TestCondValueExprInArray(t *testing.T) {
 	require.Len(t, arr.Rows[0], 3, "expected three cells")
 	cv, ok := arr.Rows[0][1].(*ast.CondValueExpr)
 	require.Truef(t, ok, "expected CondValueExpr cell, got %T", arr.Rows[0][1])
-	require.Truef(t, testInfixExpression(t, cv.Cond, "a", ">", 2), "cell cond mismatch")
+	require.Truef(t, testInfixExpression(t, cv.Condition[0], "a", ">", 2), "cell cond mismatch")
 	require.Truef(t, testIntegerLiteral(t, cv.Value, 5), "cell value mismatch")
 }
 
@@ -1005,7 +1035,7 @@ func TestCondValueAttachedPrefixSharedDetection(t *testing.T) {
 	require.Len(t, stmt.Value, 1, "expected one value")
 	cv, ok := stmt.Value[0].(*ast.CondValueExpr)
 	require.Truef(t, ok, "expected *ast.CondValueExpr, got %T", stmt.Value[0])
-	require.Truef(t, testInfixExpression(t, cv.Cond, "a", ">", 2), "cond mismatch")
+	require.Truef(t, testInfixExpression(t, cv.Condition[0], "a", ">", 2), "cond mismatch")
 	pre, ok := cv.Value.(*ast.PrefixExpression)
 	require.Truef(t, ok, "expected prefix value, got %T", cv.Value)
 	require.Equal(t, "-", pre.Operator)

--- a/tests/cond/cond_value.exp
+++ b/tests/cond/cond_value.exp
@@ -35,3 +35,25 @@ CvCellRangeVal: [2 4 6 8 10]
 CvCellMultiDriver: [2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 4 6 8 10]
 CvRootArith: 19
 CvRootHeap: his4
+CjBothTrue: 10
+CjOneFalse: 0
+CjAllFalse: 0
+CjThree: 7
+CjFbFalse: 7
+CjFbTrue: 10
+CjChain: 42
+CjArr: [9 0 7]
+CjRangeArr: [0 0 2 3 0]
+CjStrTrue: hello world
+CjStrFalse: 
+CjStrFb: fallback
+CjMultiTrue: 10 20
+CjMultiFalse: 0 0
+CjRangeHeap: s4
+CjMcBoth: 7
+CjMcFail: 0
+CjMcMulti: 8 9
+CjMcStr: match
+CjMcStrF: 
+CjMcStrHeapVal: s9?
+CjMcCombo: 7

--- a/tests/cond/cond_value.spt
+++ b/tests/cond/cond_value.spt
@@ -155,3 +155,83 @@ cvRootArith = cvX + (cvA > 2 3gi + 5)
 cvSm = "hi"
 cvRootHeap = cvSm ⊕ (cvA > 2 MkStr(gi))
 "CvRootHeap: -cvRootHeap"
+
+# Conjunction conditions: comma-separated conditions are ANDed (the value yields
+# only when every condition holds), mirroring the statement level. A failed
+# conjunction resolves locally to zero (or a trailing || fallback overrides).
+cjBothTrue = (a > 2, a > 0 10)
+"CjBothTrue: -cjBothTrue"
+cjOneFalse = (a > 2, b > 2 10)
+"CjOneFalse: -cjOneFalse"
+cjAllFalse = (a > 9, b > 9 10)
+"CjAllFalse: -cjAllFalse"
+
+# Three conditions ANDed.
+cjThree = (a > 2, a > 3, a > 4 7)
+"CjThree: -cjThree"
+
+# Conjunction with a fallback ||: the fallback wins when any condition fails.
+cjFbFalse = (a > 2, b > 2 10) || 7
+"CjFbFalse: -cjFbFalse"
+cjFbTrue = (a > 2, a > 0 10) || 7
+"CjFbTrue: -cjFbTrue"
+
+# A chained comparison may be one of the conjuncts (2 < a < 8 AND a > 0).
+cjChain = (a > 2 < 8, a > 0 42)
+"CjChain: -cjChain"
+
+# Conjunction in array cells: true cell keeps the value, false cell zero-fills.
+cjArr = [(a > 2, a > 0 9) (a > 2, b > 2 9) 7]
+"CjArr: -cjArr"
+
+# Range-driven conjunction in a collector: keep gi only where 1 < gi < 4.
+cjRangeArr = [(gi > 1, gi < 4 gi)]
+"CjRangeArr: -cjRangeArr"
+
+# Conjunction gating a heap string value: true yields the concat, false yields
+# the empty string, and a fallback overrides the zero (no leak on any arm).
+cjStrTrue = (a > 2, a > 0 sl ⊕ sm)
+"CjStrTrue: -cjStrTrue"
+cjStrFalse = (a > 2, b > 2 sl ⊕ sm)
+"CjStrFalse: -cjStrFalse"
+cjStrFb = (a > 2, b > 2 sl ⊕ sm) || "fallback"
+"CjStrFb: -cjStrFb"
+
+# Conjunction with a multi-return value: all slots yield, or all zero on failure.
+cjMa, cjMb = (a > 2, a > 0 Pair(10, 20))
+"CjMultiTrue: -cjMa -cjMb"
+cjMc, cjMd = (a > 2, b > 2 Pair(10, 20))
+"CjMultiFalse: -cjMc -cjMd"
+
+# Range-root conjunction with a heap value: the per-iteration string is freed
+# before the next overwrite (no leak across iterations); the final value wins.
+cjRangeHeap = (gi >= 0, gi < 9 MkStr(gi))
+"CjRangeHeap: -cjRangeHeap"
+
+# Multi-cell comparison condition: a comparison of multi-return operands
+# (Pair > Pair) gates on the cell-wise conjunction — every cell must hold,
+# matching the statement level. The value yields only then.
+cjMcBoth = (Pair(1, 2) > Pair(0, 1) 7)
+"CjMcBoth: -cjMcBoth"
+cjMcFail = (Pair(1, 2) > Pair(0, 2) 7)
+"CjMcFail: -cjMcFail"
+
+# Multi-cell comparison gating a multi-return value.
+cjMcA, cjMcB = (Pair(3, 4) > Pair(1, 1) Pair(8, 9))
+"CjMcMulti: -cjMcA -cjMcB"
+
+# Multi-cell comparison over heap strings: PairStr returns a pair of heap
+# strings (built with ⊕ inside the function), so each compared cell is a heap
+# value whose ownership transfers across the call. Every cell is freed after
+# gating (no leak). True yields the value; a failing cell yields empty; the
+# value itself may be heap too.
+cjMcStr = (PairStr(3, 1) > PairStr(2, 0) "match")
+"CjMcStr: -cjMcStr"
+cjMcStrF = (PairStr(3, 1) > PairStr(2, 5) "match")
+"CjMcStrF: -cjMcStrF"
+cjMcStrHeapVal = (PairStr(3, 1) > PairStr(2, 0) MkStr(9) ⊕ "?")
+"CjMcStrHeapVal: -cjMcStrHeapVal"
+
+# A multi-cell comparison may itself be one conjunct of a comma-AND list.
+cjMcCombo = (Pair(1, 2) > Pair(0, 1), a > 2 7)
+"CjMcCombo: -cjMcCombo"

--- a/tests/cond/value_cond_expr.exp
+++ b/tests/cond/value_cond_expr.exp
@@ -58,7 +58,10 @@ re:StrEqFalse:\s*
 RangeStrMixed: s3
 RangeStrMixedBranches: s3
 re:RangeStrFalse:\s*
-NonValueCmp: 1
+ArgValuePos: 5
+ArgChained: 5
+ArgRun: 105
+ArgSkip: 0
 LogicalOrLeft: 5
 LogicalOrRight: 7
 LogicalOrFalse: 0
@@ -140,3 +143,7 @@ RootChainPrint:
 25
 RootChainPrintFalse:
 0
+SmcCondTrue: 7
+SmcCondKeepOld: 99
+SmcCondMulti: 8 9
+SmcCondStr: 42

--- a/tests/cond/value_cond_expr.pt
+++ b/tests/cond/value_cond_expr.pt
@@ -18,3 +18,10 @@ res = Id(x)
 
 s = MkStr(x)
     s = "s-x"
+
+res = Inc(x)
+    res = x + 100
+
+p, q = PairStr(x, y)
+    p = MkStr(x) ⊕ "!"
+    q = MkStr(y) ⊕ "!"

--- a/tests/cond/value_cond_expr.spt
+++ b/tests/cond/value_cond_expr.spt
@@ -244,10 +244,22 @@ rgm = MkStr(1:4) > "s2"
 rg2 = MkStr(1:4) > "z"
 "RangeStrFalse: -rg2"
 
-# Comparison in non-value position (function arg) must not be treated as cond-expr
-ga = 1
-gb = Id(ga > 0)
-"NonValueCmp: -gb"
+# A comparison in a function argument is value-position: it yields its gated LHS
+# (not a boolean), and chains. Set the operand so the value reading differs from
+# the boolean one (5, not 1), which the old ga=1 case could not distinguish.
+ga = 5
+argValue = Id(ga > 0)
+"ArgValuePos: -argValue"
+argChained = Id(ga > 2 < 8)
+"ArgChained: -argChained"
+
+# A failing gate in an argument skips the call rather than running it on a
+# zero-filled 0: Inc(x)=x+100, so a skipped call yields 0, not Inc(0)=100.
+argRun = Inc(ga > 0)
+"ArgRun: -argRun"
+gz = 0
+argSkip = Inc(gz > 2)
+"ArgSkip: -argSkip"
 
 # Logical OR in value position picks the first true conditional value.
 lorLeft = a > 2 || d < 10
@@ -536,3 +548,18 @@ rootC = 5
 rootD = 1
 "RootChainPrintFalse:"
 (rootD > 2 < 8  rootD * rootD)
+
+# Statement-level multi-cell comparison condition: the gate is the cell-wise AND
+# of a multi-return comparison (like a single comparison), with keep-old on
+# failure. Mirrors the (cond value) multi-cell form so the rule holds everywhere.
+smcTrue = Pair(1, 2) > Pair(0, 1) 7
+"SmcCondTrue: -smcTrue"
+smcExist = 99
+smcExist = Pair(1, 2) > Pair(0, 2) 7
+"SmcCondKeepOld: -smcExist"
+smcM, smcN = Pair(3, 4) > Pair(1, 1) 8, 9
+"SmcCondMulti: -smcM -smcN"
+# Heap string pair (PairStr returns ⊕-built heap strings) in a multi-cell gate:
+# the returned heap cells are freed after gating (no leak).
+smcStr = PairStr(3, 1) > PairStr(2, 0) 42
+"SmcCondStr: -smcStr"


### PR DESCRIPTION
## Summary

A condition slot now accepts **multiple conditions ANDed together**, in two forms, working everywhere a condition appears (statement gate, `(cond value)`, array cell):

| Form | Example | Semantics |
|---|---|---|
| Comma-AND list | `(a > 2, b > 3  v)` | value yields only when all conditions hold |
| Multi-cell comparison | `(Pair(1, 2) > Pair(0, 1)  v)` | gates on the cell-wise AND of the slots |

This is the conjunction follow-up tabled out of the merged `(cond value)` feature (#58).

## Behaviour

```pluto
both = (a > 2, b > 2  10)            # 10 when both hold, else 0  (local-zero)
mc   = (Pair(1,2) > Pair(0,1)  7)    # 7  (cell-wise AND)
fb   = (a > 2, b > 9  10) || 7       # 7  (fallback when the conjunction fails)
x = Pair(1,2) > Pair(0,1)  v         # statement gate, cell-wise AND, keep-old
```

Precedence: comma binds looser than `||`, so `a > 2, b > 2 || c` is `a > 2` **AND** `(b > 2 || c)`.

## Implementation

- **ast** — `CondValueExpr.Cond` → `Condition []Expression` (String/ExprChildren/RewriteExpr updated).
- **parser** — `parseGroupedExpression` gathers a comma-separated condition list (reusing `conditionsOk`) before the value. A multi-cell comparison is already a single infix, so it needs no parser change.
- **solver** — each conjunct is validated independently; dropped the single-value rejection in both `typeCondValueExpr` and `validateStatementCondition`, relying on `conditionCanFail` + a new `typesResolved` guard. A non-comparison or always-yielding `||` is still rejected.
- **compiler** — extracted `andGates` (the gate AND-loop) for the condition list; codegen is otherwise unchanged — `handleComparisons` already AND-reduces multi-return comparison slots and frees the heap LHS.

## Heap safety

Multi-cell comparisons over heap strings are leak-tested via a new `PairStr` helper that *returns* a pair of `⊕`-built heap strings (genuine ownership transfer across a multi-return boundary). IR shows real `@str_concat`/`@strdup` allocations balanced by `@free`; `leaks` reports 0.

## Also

Fixes the stale `NonValueCmp` test — its comment was wrong (function args **are** value-position) and its assertion was indistinguishable at `ga=1`; rewritten with an `Inc` helper to prove a failed gate skips the call.

## Tests

- Parser: multi-condition shape + value-less-list error
- Solver diagnostics: non-failable conjunct, identifier conjunct
- E2E (`tests/cond/cond_value.spt`, `value_cond_expr.spt`): comma-AND and multi-cell over int / heap string / multi-return / fallback / ranges / array cells, at both statement and `(cond value)` level

Verification: `go test -race ./lexer ./parser ./compiler` · `python3 test.py` (60/60) · `python3 test.py --leak-check tests/cond` (no leaks) · gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
