### PR TITLE
feat(format): apply scalar specifiers to array elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ words = ["hello" "hello world" ""]
 words  # ["hello" "hello world" ""]
 ```
 
+Compatible scalar format specifiers lift element-wise over arrays. For example,
+`"-ints%4d"` pads every integer, `"-values%7.2f"` formats every float, and
+`"-ints%#x"` prints every integer in hexadecimal. String arrays stay quoted by
+default; an explicit `"-words%s"` prints their elements without quotes.
+
 An unescaped `%` immediately after a resolved marker starts a strict format specifier. Use `%%` or
 `\%` for a literal percent after a value, so `"Progress: -n%%"` prints a value followed by `%`;
 `-n%05d` applies custom formatting and `-n% d` reserves a leading space for a positive number.

--- a/compiler/array.go
+++ b/compiler/array.go
@@ -805,10 +805,6 @@ func (c *Compiler) compileArrayUnaryPrefix(op string, arr *Symbol, result Array)
 
 func (c *Compiler) arrayStrArg(s *Symbol) llvm.Value {
 	arr := s.Type.(Array)
-	if len(arr.ColTypes) != 1 {
-		panic("internal: arrayStrArg supports only single-column vectors")
-	}
-
 	elemType := arr.ColTypes[0]
 	info, ok := ArrayInfos[elemType.Kind()]
 	if !ok {

--- a/compiler/array.go
+++ b/compiler/array.go
@@ -820,18 +820,9 @@ func (c *Compiler) arrayStrArg(s *Symbol) llvm.Value {
 	return c.builder.CreateCall(fnTy, fn, []llvm.Value{cast}, "arr_str")
 }
 
-func (c *Compiler) arrayFormatArg(s *Symbol, elementFormat string, dynamicArgs []*Symbol) llvm.Value {
+func (c *Compiler) arrayFormatArg(s *Symbol, info ArrayInfo, elementFormat string, dynamicArgs []*Symbol) llvm.Value {
 	if len(dynamicArgs) > 2 {
 		panic("internal: array element format has more than two dynamic arguments")
-	}
-
-	arr := s.Type.(Array)
-	if len(arr.ColTypes) != 1 {
-		panic("internal: arrayFormatArg supports only single-column vectors")
-	}
-	info, ok := ArrayInfos[arr.ColTypes[0].Kind()]
-	if !ok {
-		panic("internal: unsupported array element kind for formatting")
 	}
 
 	i32 := c.Context.Int32Type()

--- a/compiler/array.go
+++ b/compiler/array.go
@@ -16,6 +16,7 @@ type ArrayInfo struct {
 	GetName    string
 	LenName    string
 	StrName    string
+	FormatName string
 	PushName   string
 }
 
@@ -35,6 +36,7 @@ var ArrayInfos = map[Kind]ArrayInfo{
 		GetName:    ARR_I64_GET,
 		LenName:    ARR_I64_LEN,
 		StrName:    ARR_I64_STR,
+		FormatName: ARR_I64_FORMAT,
 		PushName:   ARR_I64_PUSH,
 	},
 	FloatKind: {
@@ -45,6 +47,7 @@ var ArrayInfos = map[Kind]ArrayInfo{
 		GetName:    ARR_F64_GET,
 		LenName:    ARR_F64_LEN,
 		StrName:    ARR_F64_STR,
+		FormatName: ARR_F64_FORMAT,
 		PushName:   ARR_F64_PUSH,
 	},
 	StrKind: {
@@ -55,6 +58,7 @@ var ArrayInfos = map[Kind]ArrayInfo{
 		GetName:    ARR_STR_GET,
 		LenName:    ARR_STR_LEN,
 		StrName:    ARR_STR_STR,
+		FormatName: ARR_STR_FORMAT,
 		PushName:   ARR_STR_PUSH,
 	},
 }
@@ -814,6 +818,37 @@ func (c *Compiler) arrayStrArg(s *Symbol) llvm.Value {
 	cast := c.ArrayBitCast(s.Val, info, "arr_cast")
 	fnTy, fn := c.GetCFunc(info.StrName)
 	return c.builder.CreateCall(fnTy, fn, []llvm.Value{cast}, "arr_str")
+}
+
+func (c *Compiler) arrayFormatArg(s *Symbol, elementFormat string, dynamicArgs []*Symbol) llvm.Value {
+	if len(dynamicArgs) > 2 {
+		panic("internal: array element format has more than two dynamic arguments")
+	}
+
+	arr := s.Type.(Array)
+	if len(arr.ColTypes) != 1 {
+		panic("internal: arrayFormatArg supports only single-column vectors")
+	}
+	info, ok := ArrayInfos[arr.ColTypes[0].Kind()]
+	if !ok {
+		panic("internal: unsupported array element kind for formatting")
+	}
+
+	i32 := c.Context.Int32Type()
+	zero := llvm.ConstInt(i32, 0, false)
+	formatArgs := []llvm.Value{
+		c.ArrayBitCast(s.Val, info, "arr_format_cast"),
+		c.constCString(elementFormat),
+		llvm.ConstInt(i32, uint64(len(dynamicArgs)), false),
+		zero,
+		zero,
+	}
+	for i, dynamicArg := range dynamicArgs {
+		formatArgs[i+3] = c.formatCIntArg(dynamicArg, "array_format_size_i32")
+	}
+
+	fnTy, fn := c.GetCFunc(info.FormatName)
+	return c.builder.CreateCall(fnTy, fn, formatArgs, "arr_format")
 }
 
 func (c *Compiler) arrayRangeStrArgs(s *Symbol) (arrayStr llvm.Value, rangeStr llvm.Value) {

--- a/compiler/array.go
+++ b/compiler/array.go
@@ -821,10 +821,6 @@ func (c *Compiler) arrayStrArg(s *Symbol) llvm.Value {
 }
 
 func (c *Compiler) arrayFormatArg(s *Symbol, info ArrayInfo, elementFormat string, dynamicArgs []*Symbol) llvm.Value {
-	if len(dynamicArgs) > 2 {
-		panic("internal: array element format has more than two dynamic arguments")
-	}
-
 	i32 := c.Context.Int32Type()
 	zero := llvm.ConstInt(i32, 0, false)
 	formatArgs := []llvm.Value{

--- a/compiler/cfuncs.go
+++ b/compiler/cfuncs.go
@@ -26,6 +26,7 @@ const (
 	ARR_I64_GET    = "arr_i64_get"
 	ARR_I64_LEN    = "arr_i64_len"
 	ARR_I64_STR    = "arr_i64_str"
+	ARR_I64_FORMAT = "arr_i64_format"
 	ARR_I64_PUSH   = "arr_i64_push"
 	ARR_I64_FREE   = "arr_i64_free"
 	ARR_I64_COPY   = "arr_i64_copy"
@@ -37,6 +38,7 @@ const (
 	ARR_F64_GET    = "arr_f64_get"
 	ARR_F64_LEN    = "arr_f64_len"
 	ARR_F64_STR    = "arr_f64_str"
+	ARR_F64_FORMAT = "arr_f64_format"
 	ARR_F64_PUSH   = "arr_f64_push"
 	ARR_F64_FREE   = "arr_f64_free"
 	ARR_F64_COPY   = "arr_f64_copy"
@@ -50,6 +52,7 @@ const (
 	ARR_STR_BORROW   = "arr_str_borrow"
 	ARR_STR_LEN      = "arr_str_len"
 	ARR_STR_STR      = "arr_str_str"
+	ARR_STR_FORMAT   = "arr_str_format"
 	ARR_STR_PUSH     = "arr_str_push"
 	ARR_STR_PUSH_OWN = "arr_str_push_own"
 	ARR_STR_FREE     = "arr_str_free"
@@ -61,6 +64,7 @@ const (
 func (c *Compiler) GetFnType(name string) llvm.Type {
 	// Short helpers to reduce duplication
 	charPtr := llvm.PointerType(c.Context.Int8Type(), 0)
+	i32 := c.Context.Int32Type()
 	i64 := c.Context.Int64Type()
 	f64 := c.Context.DoubleType()
 
@@ -104,6 +108,8 @@ func (c *Compiler) GetFnType(name string) llvm.Type {
 		return llvm.FunctionType(i64, []llvm.Type{c.NamedOpaquePtr("PtArrayI64")}, false)
 	case ARR_I64_STR:
 		return llvm.FunctionType(charPtr, []llvm.Type{c.NamedOpaquePtr("PtArrayI64")}, false)
+	case ARR_I64_FORMAT:
+		return llvm.FunctionType(charPtr, []llvm.Type{c.NamedOpaquePtr("PtArrayI64"), charPtr, i32, i32, i32}, false)
 	case ARR_I64_PUSH:
 		pt := c.NamedOpaquePtr("PtArrayI64")
 		return llvm.FunctionType(c.Context.Int32Type(), []llvm.Type{pt, i64}, false)
@@ -126,6 +132,8 @@ func (c *Compiler) GetFnType(name string) llvm.Type {
 		return llvm.FunctionType(i64, []llvm.Type{c.NamedOpaquePtr("PtArrayF64")}, false)
 	case ARR_F64_STR:
 		return llvm.FunctionType(charPtr, []llvm.Type{c.NamedOpaquePtr("PtArrayF64")}, false)
+	case ARR_F64_FORMAT:
+		return llvm.FunctionType(charPtr, []llvm.Type{c.NamedOpaquePtr("PtArrayF64"), charPtr, i32, i32, i32}, false)
 	case ARR_F64_PUSH:
 		pt := c.NamedOpaquePtr("PtArrayF64")
 		return llvm.FunctionType(c.Context.Int32Type(), []llvm.Type{pt, f64}, false)
@@ -150,6 +158,8 @@ func (c *Compiler) GetFnType(name string) llvm.Type {
 		return llvm.FunctionType(i64, []llvm.Type{c.NamedOpaquePtr("PtArrayStr")}, false)
 	case ARR_STR_STR:
 		return llvm.FunctionType(charPtr, []llvm.Type{c.NamedOpaquePtr("PtArrayStr")}, false)
+	case ARR_STR_FORMAT:
+		return llvm.FunctionType(charPtr, []llvm.Type{c.NamedOpaquePtr("PtArrayStr"), charPtr, i32, i32, i32}, false)
 	case ARR_STR_PUSH, ARR_STR_PUSH_OWN:
 		pt := c.NamedOpaquePtr("PtArrayStr")
 		return llvm.FunctionType(c.Context.Int32Type(), []llvm.Type{pt, charPtr}, false)

--- a/compiler/format.go
+++ b/compiler/format.go
@@ -455,10 +455,14 @@ func arrayElementSupportsSpecifier(element Type, conversion rune) bool {
 	return ok && expectedKind == element.Kind()
 }
 
-func (c *Compiler) formatArrayElements(tok token.Token, value string, mainSym *Symbol, syms []*Symbol, spec parsedSpecifier) (formattedMarker, bool, *token.CompileError) {
+func (c *Compiler) tryFormatArrayElements(tok token.Token, value string, mainSym *Symbol, syms []*Symbol, spec parsedSpecifier) (formattedMarker, bool, *token.CompileError) {
+	if mainSym.Type.Kind() != ArrayKind {
+		return formattedMarker{}, false, nil
+	}
 	if spec.text == "" || spec.text == "%%" {
 		return formattedMarker{}, false, nil
 	}
+
 	arr := mainSym.Type.(Array)
 	elementType := arr.ColTypes[0]
 	conversion := rune(spec.text[len(spec.text)-1])
@@ -470,6 +474,7 @@ func (c *Compiler) formatArrayElements(tok token.Token, value string, mainSym *S
 		return formattedMarker{}, false, nil
 	}
 	if err := validateHexSpecifierType(tok, value, elementType, conversion, spec); err != nil {
+		c.Errors = append(c.Errors, err)
 		return formattedMarker{}, true, err
 	}
 
@@ -676,16 +681,11 @@ func (c *Compiler) formatSpecialValue(tok token.Token, mainID string, mainSym *S
 // matching arguments. syms contains the main value followed by dynamic sizes.
 func (c *Compiler) parseFormatting(tok token.Token, value, mainID string, syms []*Symbol, spec parsedSpecifier) (formattedMarker, *token.CompileError) {
 	mainSym := syms[0]
-	if mainSym.Type.Kind() == ArrayKind {
-		result, handled, err := c.formatArrayElements(tok, value, mainSym, syms, spec)
-		if err != nil {
-			c.Errors = append(c.Errors, err)
-			return formattedMarker{}, err
-		}
-		if handled {
-			return result, nil
-		}
+
+	if result, handled, err := c.tryFormatArrayElements(tok, value, mainSym, syms, spec); handled {
+		return result, err
 	}
+
 	customSpec := spec.text
 	transformedPrecision := spec.precision.present && transformedStringSpecifier(mainSym.Type, customSpec)
 	var byteLimit *llvm.Value
@@ -698,6 +698,7 @@ func (c *Compiler) parseFormatting(tok token.Token, value, mainID string, syms [
 			return formattedMarker{}, precisionErr
 		}
 	}
+
 	text, specRune, buildErr := formatMarkerSpec(mainSym.Type, customSpec)
 	if buildErr != nil {
 		err := &token.CompileError{
@@ -719,6 +720,7 @@ func (c *Compiler) parseFormatting(tok token.Token, value, mainID string, syms [
 		}
 		result.args = append(result.args, c.formatCIntArg(specSym, "format_size_i32"))
 	}
+
 	handled, err := c.formatSpecialValue(tok, mainID, mainSym, spec, specRune, byteLimit, &result)
 	if err != nil {
 		c.Errors = append(c.Errors, err)
@@ -727,11 +729,13 @@ func (c *Compiler) parseFormatting(tok token.Token, value, mainID string, syms [
 	if handled {
 		return result, nil
 	}
+
 	if directSpecToKind[specRune] != mainSym.Type.Kind() {
 		err := formatSpecifierTypeError(tok, specRune, mainID, mainSym.Type)
 		c.Errors = append(c.Errors, err)
 		return formattedMarker{}, err
 	}
+
 	result.args = append(result.args, mainSym.Val)
 	return result, nil
 }
@@ -752,6 +756,7 @@ func (c *Compiler) formatString(tok token.Token, value string) (string, []llvm.V
 	// literal output and are never reconsidered as markers or specifiers.
 	runes := []rune(value)
 	i := 0
+
 	for i < len(runes) {
 		if runes[i] == '\\' {
 			decoded, next, _ := lexer.DecodeStringEscape(runes, i)
@@ -759,11 +764,13 @@ func (c *Compiler) formatString(tok token.Token, value string) (string, []llvm.V
 			i = next
 			continue
 		}
+
 		if !maybeMarker(runes, i) {
 			writeFormatText(&builder, string(runes[i]))
 			i++
 			continue
 		}
+
 		// If we see a '-' and the next rune is a valid identifier start...
 		// Parse the marker.
 		marker, err := c.parseMarker(tok, value, runes, i)
@@ -773,16 +780,20 @@ func (c *Compiler) formatString(tok token.Token, value string) (string, []llvm.V
 			i = marker.end
 			continue
 		}
+
 		if err != nil {
 			return "", args, nil
 		}
+
 		formatted, err := c.parseFormatting(tok, value, marker.mainID, marker.symbols, marker.specifier)
 		if err != nil {
 			return "", args, nil
 		}
+
 		builder.WriteString(formatted.text)
 		args = append(args, formatted.args...)
 		toFree = append(toFree, formatted.toFree...)
+
 		// Advance past the marker.
 		i = marker.end
 	}
@@ -803,6 +814,7 @@ func upgradeIntSpec(spec string) string {
 	if len(spec) < 2 || spec[0] != '%' {
 		return spec
 	}
+
 	conv := spec[len(spec)-1]
 	switch conv {
 	case 'd', 'i', 'u', 'o', 'x', 'X', 'n':
@@ -810,13 +822,13 @@ func upgradeIntSpec(spec string) string {
 	default:
 		return spec
 	}
+
 	body := spec[1 : len(spec)-1]
 	if strings.HasSuffix(body, "ll") {
 		return spec
 	}
-	if strings.HasSuffix(body, "l") {
-		body = body[:len(body)-1]
-	}
+
+	body = strings.TrimSuffix(body, "l")
 	return "%" + body + "ll" + string(conv)
 }
 

--- a/compiler/format.go
+++ b/compiler/format.go
@@ -447,6 +447,44 @@ type formattedMarker struct {
 	toFree []llvm.Value
 }
 
+func arrayElementSupportsSpecifier(element Type, conversion rune) bool {
+	if conversion == 'c' {
+		return element.Kind() == IntKind
+	}
+	expectedKind, ok := directSpecToKind[conversion]
+	return ok && expectedKind == element.Kind()
+}
+
+func (c *Compiler) formatArrayElements(tok token.Token, value string, mainSym *Symbol, syms []*Symbol, spec parsedSpecifier) (formattedMarker, bool, *token.CompileError) {
+	if spec.text == "" || spec.text == "%%" {
+		return formattedMarker{}, false, nil
+	}
+	arr := mainSym.Type.(Array)
+	if len(arr.ColTypes) != 1 {
+		return formattedMarker{}, false, nil
+	}
+
+	elementType := arr.ColTypes[0]
+	conversion := rune(spec.text[len(spec.text)-1])
+	if !arrayElementSupportsSpecifier(elementType, conversion) {
+		return formattedMarker{}, false, nil
+	}
+	if err := validateHexSpecifierType(tok, value, elementType, conversion, spec); err != nil {
+		return formattedMarker{}, true, err
+	}
+
+	elementFormat := spec.text
+	if elementType.Kind() == IntKind {
+		elementFormat = upgradeIntSpec(elementFormat)
+	}
+	formatted := c.arrayFormatArg(mainSym, elementFormat, syms[1:])
+	return formattedMarker{
+		text:   "%s",
+		args:   []llvm.Value{formatted},
+		toFree: []llvm.Value{formatted},
+	}, true, nil
+}
+
 func (c *Compiler) transformedStringPrecisionArg(tok token.Token, value string, precision specifierPrecision, syms []*Symbol) (*llvm.Value, *token.CompileError) {
 	if !precision.present {
 		return nil, nil
@@ -638,6 +676,16 @@ func (c *Compiler) formatSpecialValue(tok token.Token, mainID string, mainSym *S
 // matching arguments. syms contains the main value followed by dynamic sizes.
 func (c *Compiler) parseFormatting(tok token.Token, value, mainID string, syms []*Symbol, spec parsedSpecifier) (formattedMarker, *token.CompileError) {
 	mainSym := syms[0]
+	if mainSym.Type.Kind() == ArrayKind {
+		result, handled, err := c.formatArrayElements(tok, value, mainSym, syms, spec)
+		if err != nil {
+			c.Errors = append(c.Errors, err)
+			return formattedMarker{}, err
+		}
+		if handled {
+			return result, nil
+		}
+	}
 	customSpec := spec.text
 	transformedPrecision := spec.precision.present && transformedStringSpecifier(mainSym.Type, customSpec)
 	var byteLimit *llvm.Value

--- a/compiler/format.go
+++ b/compiler/format.go
@@ -469,6 +469,10 @@ func (c *Compiler) formatArrayElements(tok token.Token, value string, mainSym *S
 	if !arrayElementSupportsSpecifier(elementType, conversion) {
 		return formattedMarker{}, false, nil
 	}
+	info, ok := ArrayInfos[elementType.Kind()]
+	if !ok {
+		return formattedMarker{}, false, nil
+	}
 	if err := validateHexSpecifierType(tok, value, elementType, conversion, spec); err != nil {
 		return formattedMarker{}, true, err
 	}
@@ -477,7 +481,7 @@ func (c *Compiler) formatArrayElements(tok token.Token, value string, mainSym *S
 	if elementType.Kind() == IntKind {
 		elementFormat = upgradeIntSpec(elementFormat)
 	}
-	formatted := c.arrayFormatArg(mainSym, elementFormat, syms[1:])
+	formatted := c.arrayFormatArg(mainSym, info, elementFormat, syms[1:])
 	return formattedMarker{
 		text:   "%s",
 		args:   []llvm.Value{formatted},

--- a/compiler/format.go
+++ b/compiler/format.go
@@ -460,10 +460,6 @@ func (c *Compiler) formatArrayElements(tok token.Token, value string, mainSym *S
 		return formattedMarker{}, false, nil
 	}
 	arr := mainSym.Type.(Array)
-	if len(arr.ColTypes) != 1 {
-		return formattedMarker{}, false, nil
-	}
-
 	elementType := arr.ColTypes[0]
 	conversion := rune(spec.text[len(spec.text)-1])
 	if !arrayElementSupportsSpecifier(elementType, conversion) {

--- a/docs/Pluto IR Plan.md
+++ b/docs/Pluto IR Plan.md
@@ -640,7 +640,7 @@ The statement plan can grow without becoming a machine IR:
 - field, index, column, and cell targets extend `set`
 - member calls remain solved expressions inside `eval` or `map`
 - source `break` and `continue` extend structured range actions
-- `return` can reuse outcome planning with a different final action
+- function-result transfer can reuse outcome planning with a different final action
 - conditional arrays extend domains, alignment, and yield masks
 - gated prints become a statement plan whose final action prints yielded
   outcomes instead of setting targets

--- a/docs/Pluto String and Formatting Semantics.md
+++ b/docs/Pluto String and Formatting Semantics.md
@@ -118,6 +118,38 @@ Supported conversions are:
 | `n` | writable `I64` byte-count target |
 | `%` | default-formatted value followed by `%` |
 
+## Array element formatting
+
+A compatible scalar conversion attached to an array marker is applied to every
+element. The brackets and single-space element separators remain part of the
+array representation; width and precision apply independently to each element.
+
+```pluto
+ints = [1 20 255]
+values = [1.5 2.25]
+words = ["hello" "hello world"]
+
+"-ints%4d"       # [   1   20  255]
+"-ints%#x"       # [0x1 0x14 0xff]
+"-values%7.2f"   # [   1.50    2.25]
+"-words%s"       # [hello hello world]
+```
+
+The supported element conversions are:
+
+| Array element type | Conversions |
+| --- | --- |
+| `I64` | `d`, `i`, `u`, `o`, `x`, `X`, `c` |
+| `F64` | `f`, `F`, `e`, `E`, `g`, `G`, `a`, `A` |
+| `Str` | `s` |
+
+Static and dynamic width and precision use the normal grammar. For example,
+`"-values%(-width).(-precision)f"` applies the same runtime width and precision
+to every element. Without a custom conversion, array defaults are unchanged:
+string elements remain quoted and escaped. Explicit `%s` on a string array is
+intentionally unquoted and can therefore be ambiguous when elements contain
+spaces or are empty.
+
 Only `l` and `ll` length modifiers are accepted, and only for integer
 conversions. Pluto normalizes integer formatting to its `I64` calling
 convention. Other C length modifiers are rejected.

--- a/docs/Pluto String and Formatting Semantics.md
+++ b/docs/Pluto String and Formatting Semantics.md
@@ -150,6 +150,10 @@ string elements remain quoted and escaped. Explicit `%s` on a string array is
 intentionally unquoted and can therefore be ambiguous when elements contain
 spaces or are empty.
 
+Array `%c` follows C's conversion through `unsigned char`. Because Pluto strings
+cannot contain NUL, a resulting NUL is rendered as the visible text `\x00`;
+field width applies to that rendered representation.
+
 Only `l` and `ll` length modifiers are accepted, and only for integer
 conversions. Pluto normalizes integer formatting to its `I64` calling
 convention. Other C length modifiers are rejected.

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -297,12 +297,17 @@ static int strbuf_printf(StrBuf* sb, const char* fmt, ...) {
      (COUNT) == 1 ? strbuf_printf((SB), (FMT), (FIRST), (VALUE)) :   \
      (COUNT) == 2 ? strbuf_printf((SB), (FMT), (FIRST), (SECOND), (VALUE)) : -1)
 
-static int strbuf_format_i64(StrBuf* sb, const char* fmt, int dynamic_arg_count,
-                             int first_arg, int second_arg, int64_t value) {
-    if (!fmt || !*fmt) return -1;
-    char conversion = fmt[strlen(fmt) - 1];
+static int strbuf_format_i64(StrBuf* sb, const char* fmt, const char* escaped_nul_fmt,
+                             char conversion, int dynamic_arg_count, int first_arg,
+                             int second_arg, int64_t value) {
     if (conversion == 'c') {
-        return PT_STRBUF_FORMAT_VALUE(sb, fmt, dynamic_arg_count, first_arg, second_arg, (int)value);
+        unsigned char char_value = (unsigned char)value;
+        if (char_value != '\0') {
+            return PT_STRBUF_FORMAT_VALUE(sb, fmt, dynamic_arg_count, first_arg, second_arg,
+                                         (int)char_value);
+        }
+        return PT_STRBUF_FORMAT_VALUE(sb, escaped_nul_fmt, dynamic_arg_count,
+                                      first_arg, second_arg, "\\x00");
     }
     if (conversion == 'u' || conversion == 'o' || conversion == 'x' || conversion == 'X') {
         return PT_STRBUF_FORMAT_VALUE(sb, fmt, dynamic_arg_count, first_arg, second_arg,
@@ -373,19 +378,32 @@ const char* arr_str_str(const PtArrayStr* a) {
 
 const char* arr_i64_format(const PtArrayI64* a, const char* fmt,
                            int dynamic_arg_count, int first_arg, int second_arg) {
-    StrBuf sb = {malloc(256), 0, 256};
-    if (!sb.data) return NULL;
-    if (strbuf_printf(&sb, "[") < 0) { free(sb.data); return NULL; }
-    for (size_t i = 0; i < arr_i64_len(a); ++i) {
-        if (i > 0 && strbuf_printf(&sb, " ") < 0) { free(sb.data); return NULL; }
-        if (strbuf_format_i64(&sb, fmt, dynamic_arg_count, first_arg, second_arg,
-                              arr_i64_get(a, i)) < 0) {
-            free(sb.data);
-            return NULL;
-        }
+    if (!fmt || !*fmt) return NULL;
+    size_t fmt_len = strlen(fmt);
+    char conversion = fmt[fmt_len - 1];
+    char* escaped_nul_fmt = NULL;
+    if (conversion == 'c') {
+        escaped_nul_fmt = dup_cstr(fmt);
+        if (!escaped_nul_fmt) return NULL;
+        escaped_nul_fmt[fmt_len - 1] = 's';
     }
-    if (strbuf_printf(&sb, "]") < 0) { free(sb.data); return NULL; }
+
+    StrBuf sb = {malloc(256), 0, 256};
+    if (!sb.data) { free(escaped_nul_fmt); return NULL; }
+    if (strbuf_printf(&sb, "[") < 0) goto fail;
+    for (size_t i = 0; i < arr_i64_len(a); ++i) {
+        if (i > 0 && strbuf_printf(&sb, " ") < 0) goto fail;
+        if (strbuf_format_i64(&sb, fmt, escaped_nul_fmt, conversion, dynamic_arg_count,
+                              first_arg, second_arg, arr_i64_get(a, i)) < 0) goto fail;
+    }
+    if (strbuf_printf(&sb, "]") < 0) goto fail;
+    free(escaped_nul_fmt);
     return sb.data;
+
+fail:
+    free(escaped_nul_fmt);
+    free(sb.data);
+    return NULL;
 }
 
 const char* arr_f64_format(const PtArrayF64* a, const char* fmt,

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -292,6 +292,37 @@ static int strbuf_printf(StrBuf* sb, const char* fmt, ...) {
     return 0;
 }
 
+#define PT_STRBUF_FORMAT_VALUE(SB, FMT, COUNT, FIRST, SECOND, VALUE) \
+    ((COUNT) == 0 ? strbuf_printf((SB), (FMT), (VALUE)) :            \
+     (COUNT) == 1 ? strbuf_printf((SB), (FMT), (FIRST), (VALUE)) :   \
+     (COUNT) == 2 ? strbuf_printf((SB), (FMT), (FIRST), (SECOND), (VALUE)) : -1)
+
+static int strbuf_format_i64(StrBuf* sb, const char* fmt, int dynamic_arg_count,
+                             int first_arg, int second_arg, int64_t value) {
+    if (!fmt || !*fmt) return -1;
+    char conversion = fmt[strlen(fmt) - 1];
+    if (conversion == 'c') {
+        return PT_STRBUF_FORMAT_VALUE(sb, fmt, dynamic_arg_count, first_arg, second_arg, (int)value);
+    }
+    if (conversion == 'u' || conversion == 'o' || conversion == 'x' || conversion == 'X') {
+        return PT_STRBUF_FORMAT_VALUE(sb, fmt, dynamic_arg_count, first_arg, second_arg,
+                                     (unsigned long long)value);
+    }
+    return PT_STRBUF_FORMAT_VALUE(sb, fmt, dynamic_arg_count, first_arg, second_arg,
+                                 (long long)value);
+}
+
+static int strbuf_format_f64(StrBuf* sb, const char* fmt, int dynamic_arg_count,
+                             int first_arg, int second_arg, double value) {
+    return PT_STRBUF_FORMAT_VALUE(sb, fmt, dynamic_arg_count, first_arg, second_arg, value);
+}
+
+static int strbuf_format_str(StrBuf* sb, const char* fmt, int dynamic_arg_count,
+                             int first_arg, int second_arg, const char* value) {
+    return PT_STRBUF_FORMAT_VALUE(sb, fmt, dynamic_arg_count, first_arg, second_arg,
+                                 value ? value : "");
+}
+
 const char* arr_i64_str(const PtArrayI64* a) {
     StrBuf sb = {malloc(256), 0, 256};
     if (!sb.data) return NULL;
@@ -339,3 +370,56 @@ const char* arr_str_str(const PtArrayStr* a) {
     if (strbuf_printf(&sb, "]") < 0) { free(sb.data); return NULL; }
     return sb.data;
 }
+
+const char* arr_i64_format(const PtArrayI64* a, const char* fmt,
+                           int dynamic_arg_count, int first_arg, int second_arg) {
+    StrBuf sb = {malloc(256), 0, 256};
+    if (!sb.data) return NULL;
+    if (strbuf_printf(&sb, "[") < 0) { free(sb.data); return NULL; }
+    for (size_t i = 0; i < arr_i64_len(a); ++i) {
+        if (i > 0 && strbuf_printf(&sb, " ") < 0) { free(sb.data); return NULL; }
+        if (strbuf_format_i64(&sb, fmt, dynamic_arg_count, first_arg, second_arg,
+                              arr_i64_get(a, i)) < 0) {
+            free(sb.data);
+            return NULL;
+        }
+    }
+    if (strbuf_printf(&sb, "]") < 0) { free(sb.data); return NULL; }
+    return sb.data;
+}
+
+const char* arr_f64_format(const PtArrayF64* a, const char* fmt,
+                           int dynamic_arg_count, int first_arg, int second_arg) {
+    StrBuf sb = {malloc(256), 0, 256};
+    if (!sb.data) return NULL;
+    if (strbuf_printf(&sb, "[") < 0) { free(sb.data); return NULL; }
+    for (size_t i = 0; i < arr_f64_len(a); ++i) {
+        if (i > 0 && strbuf_printf(&sb, " ") < 0) { free(sb.data); return NULL; }
+        if (strbuf_format_f64(&sb, fmt, dynamic_arg_count, first_arg, second_arg,
+                              arr_f64_get(a, i)) < 0) {
+            free(sb.data);
+            return NULL;
+        }
+    }
+    if (strbuf_printf(&sb, "]") < 0) { free(sb.data); return NULL; }
+    return sb.data;
+}
+
+const char* arr_str_format(const PtArrayStr* a, const char* fmt,
+                           int dynamic_arg_count, int first_arg, int second_arg) {
+    StrBuf sb = {malloc(256), 0, 256};
+    if (!sb.data) return NULL;
+    if (strbuf_printf(&sb, "[") < 0) { free(sb.data); return NULL; }
+    for (size_t i = 0; i < arr_str_len(a); ++i) {
+        if (i > 0 && strbuf_printf(&sb, " ") < 0) { free(sb.data); return NULL; }
+        if (strbuf_format_str(&sb, fmt, dynamic_arg_count, first_arg, second_arg,
+                              arr_str_borrow(a, i)) < 0) {
+            free(sb.data);
+            return NULL;
+        }
+    }
+    if (strbuf_printf(&sb, "]") < 0) { free(sb.data); return NULL; }
+    return sb.data;
+}
+
+#undef PT_STRBUF_FORMAT_VALUE

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -378,7 +378,6 @@ const char* arr_str_str(const PtArrayStr* a) {
 
 const char* arr_i64_format(const PtArrayI64* a, const char* fmt,
                            int dynamic_arg_count, int first_arg, int second_arg) {
-    if (!fmt || !*fmt) return NULL;
     size_t fmt_len = strlen(fmt);
     char conversion = fmt[fmt_len - 1];
     char* escaped_nul_fmt = NULL;

--- a/runtime/array.h
+++ b/runtime/array.h
@@ -65,6 +65,15 @@ const char* arr_i64_str(const PtArrayI64* a);
 const char* arr_f64_str(const PtArrayF64* a);
 const char* arr_str_str(const PtArrayStr* a);
 
+/* Element formats are compiler-validated. Dynamic width and precision values
+   appear in format order and dynamic_arg_count is therefore 0, 1, or 2. */
+const char* arr_i64_format(const PtArrayI64* a, const char* fmt,
+                          int dynamic_arg_count, int first_arg, int second_arg);
+const char* arr_f64_format(const PtArrayF64* a, const char* fmt,
+                          int dynamic_arg_count, int first_arg, int second_arg);
+const char* arr_str_format(const PtArrayStr* a, const char* fmt,
+                          int dynamic_arg_count, int first_arg, int second_arg);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/tests/array/array.exp
+++ b/tests/array/array.exp
@@ -2,6 +2,7 @@
 arr is [1 2 3 4]
 arr int padded: |[   1    2    3    4]|
 arr int hex: [0x1 0x2 0x3 0x4]
+arr chars: |[    A  \x00     B  \x00]|
 [1.5 -2.5 3 4.25]
 arr is [1.5 -2.5 3 4.25]
 arr float fixed: |[   1.50   -2.50    3.00    4.25]|

--- a/tests/array/array.exp
+++ b/tests/array/array.exp
@@ -1,9 +1,14 @@
 [1 2 3 4]
 arr is [1 2 3 4]
+arr int padded: |[   1    2    3    4]|
+arr int hex: [0x1 0x2 0x3 0x4]
 [1.5 -2.5 3 4.25]
 arr is [1.5 -2.5 3 4.25]
+arr float fixed: |[   1.50   -2.50    3.00    4.25]|
+arr float dynamic: |[    1.5    -2.5     3.0     4.2]|
 ["foo" "bar" "baz"]
 arr is ["foo" "bar" "baz"]
+arr str raw: [foo bar baz]
 quoted arr is ["hello" "hello world" "" "say \"hi\"" "slash\\" "line\nbreak" "tab\tstop" "carriage\rreturn" "back\bspace" "form\ffeed" "escape\x1b" "dash-word" "π"]
 [1 2 3 4]
 arr2 is [1 2 3 4]

--- a/tests/array/array.spt
+++ b/tests/array/array.spt
@@ -4,6 +4,8 @@ arrInt =
 ]
 arrInt
 "arr is -arrInt"
+"arr int padded: |-arrInt%4d|"
+"arr int hex: -arrInt%#x"
 
 arrFloat =
 [
@@ -11,6 +13,10 @@ arrFloat =
 ]
 arrFloat
 "arr is -arrFloat"
+"arr float fixed: |-arrFloat%7.2f|"
+arrWidth = 7
+arrPrecision = 1
+"arr float dynamic: |-arrFloat%(-arrWidth).(-arrPrecision)f|"
 
 arrStr =
 [
@@ -18,6 +24,7 @@ arrStr =
 ]
 arrStr
 "arr is -arrStr"
+"arr str raw: -arrStr%s"
 
 arrStrQuoted = ["hello" "hello world" "" "say \"hi\"" "slash\\" "line\nbreak" "tab\tstop" "carriage\rreturn" "back\bspace" "form\ffeed" "escape\x1b" "dash-word" "π"]
 "quoted arr is -arrStrQuoted"

--- a/tests/array/array.spt
+++ b/tests/array/array.spt
@@ -4,8 +4,11 @@ arrInt =
 ]
 arrInt
 "arr is -arrInt"
-"arr int padded: |-arrInt%4d|"
+arrIntWidth = 4
+"arr int padded: |-arrInt%(-arrIntWidth)d|"
 "arr int hex: -arrInt%#x"
+arrChars = [65 0 66 256]
+"arr chars: |-arrChars%5c|"
 
 arrFloat =
 [


### PR DESCRIPTION
## Summary

- lift compatible scalar format specifiers element-wise over `I64`, `F64`, and `Str` arrays
- preserve brackets, single-space separators, and existing default array output
- make explicit `%s` on string arrays print unquoted elements while default string-array output remains quoted
- reword the PIR roadmap so it does not imply that `return` will become a Pluto keyword

## Behavior

```pluto
"-ints%4d"                               # [   1   20  255]
"-ints%#x"                               # [0x1 0x14 0xff]
"-values%7.2f"                           # [   1.50    2.25]
"-values%(-width).(-precision)f"         # dynamic per-element sizing
"-words%s"                               # [hello hello world]
```

Supported element conversions:

- `I64`: `d`, `i`, `u`, `o`, `x`, `X`, `c`
- `F64`: `f`, `F`, `e`, `E`, `g`, `G`, `a`, `A`
- `Str`: `s`

## Implementation

The compiler remains responsible for parsing, type validation, integer ABI normalization, and dynamic width/precision resolution. Typed runtime helpers receive only compiler-controlled format strings and zero, one, or two validated C `int` arguments, then build the bracketed result.

## Validation

- `go test -race ./lexer ./parser ./compiler`
- `go vet ./...`
- `python3 test.py tests/array`: 13/13
- `python3 test.py --leak-check`: 60/60, no leaks
