### PR TITLE
refactor(compiler): retain destinations in LLVM temp names

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2243,8 +2243,11 @@ func (c *Compiler) makeSeededTempOutputs(dest []*ast.Identifier, outTypes []Type
 	resolved := c.resolvedDestTypes(dest, outTypes)
 	outputs := make([]*Symbol, len(resolved))
 	for i, outType := range resolved {
-		name := fmt.Sprintf("calltmp_%d", c.tmpCounter)
-		c.tmpCounter++
+		role := fmt.Sprintf("output_slot_%d", i)
+		if dest != nil && i < len(dest) {
+			role = "output_" + dest[i].Value
+		}
+		name := freshCompilerIdentifier(cPrefix, role, &c.tmpCounter).Value
 
 		var existing *Symbol
 		var exists bool

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -829,6 +829,23 @@ func TestCompilerIdentifierCannotBeSourceIdentifier(t *testing.T) {
 	require.NotEqual(t, token.IDENT, tok.Type)
 }
 
+func TestOutputTempNamesRetainDestinations(t *testing.T) {
+	code := `left, right = Pair(x)
+    left = x
+    right = x + 1`
+	script := `result = 10
+result = 1:3 < 3 result + 1
+left, right = Pair(1:2)
+result, left, right`
+
+	ir, _ := compileScriptAndCodeIR(t, "output_temp_names", code, script)
+
+	require.Contains(t, ir, "$c_cond_result_")
+	require.Contains(t, ir, "$c_cond_stage_result_")
+	require.Contains(t, ir, "$c_output_left_")
+	require.Contains(t, ir, "$c_output_right_")
+}
+
 func TestStructUnknownFieldNoSpuriousError(t *testing.T) {
 	codeA := mustParseCode(t, `p = Person
   : name age

--- a/compiler/cond.go
+++ b/compiler/cond.go
@@ -196,7 +196,7 @@ func (c *Compiler) createConditionalTempOutputs(stmt *ast.LetStatement) []Output
 func (c *Compiler) createConditionalTempOutputsFor(dest []*ast.Identifier, outTypes []Type) []OutputSlot {
 	slots := make([]OutputSlot, len(dest))
 	for i, ident := range dest {
-		tempIdent := freshCompilerIdentifier(cPrefix, "cond", &c.tmpCounter)
+		tempIdent := freshCompilerIdentifier(cPrefix, "cond_"+ident.Value, &c.tmpCounter)
 		tempName := tempIdent.Value
 
 		ptr := c.createEntryBlockAlloca(c.mapToLLVMType(outTypes[i]), tempName+".mem")
@@ -336,7 +336,7 @@ func (c *Compiler) createStageTempOutputsFor(commit []OutputSlot) []OutputSlot {
 	for i, cs := range commit {
 		outType := cs.outType
 
-		tempIdent := freshCompilerIdentifier(cPrefix, "cond_stage", &c.tmpCounter)
+		tempIdent := freshCompilerIdentifier(cPrefix, "cond_stage_"+cs.dest.Value, &c.tmpCounter)
 		tempName := tempIdent.Value
 
 		ptr := c.createEntryBlockAlloca(c.mapToLLVMType(outType), tempName+".mem")


### PR DESCRIPTION
## Summary

- include the source destination in conditional output names
- include the destination in per-iteration conditional staging names
- replace generic `calltmp_N` slots with accurate `output_<destination>_N` names
- keep the numeric counter as the uniqueness mechanism

This makes generated LLVM IR easier to inspect during the PIR migration without changing source-level behavior. For example, a slot such as `$c_cond_7.mem` now reads as `$c_cond_result_7.mem`.

Collector and iterator names remain generic because those temporaries do not have a stable destination.

## Validation

- `go test -race ./compiler -run TestOutputTempNamesRetainDestinations`
- `go test -race ./lexer ./parser ./compiler`
- `go vet ./...`
- `python3 test.py --leak-check` (63 passed, 0 failed)
