### PR TITLE
feat(compiler): derive specialization effects

### DIFF
--- a/compiler/effects.go
+++ b/compiler/effects.go
@@ -116,25 +116,23 @@ func newEffectAnalyzer(compiler *Compiler, mangled string, calleeEffects map[str
 	}
 }
 
-func (analyzer *effectAnalyzer) info(expr ast.Expression) *ExprInfo {
+func (analyzer *effectAnalyzer) exprInfo(expr ast.Expression) *ExprInfo {
 	return analyzer.compiler.ExprCache[key(analyzer.funcNameMangled, expr)]
 }
 
 func (analyzer *effectAnalyzer) invalidExprEffects(expr ast.Expression) []YieldEffect {
-	info := analyzer.info(expr)
-	count := 1
-	if info != nil && len(info.OutTypes) > 0 {
-		count = len(info.OutTypes)
+	info := analyzer.exprInfo(expr)
+	if info == nil {
+		return []YieldEffect{YieldInvalid}
 	}
+	count := max(1, len(info.OutTypes))
 	effects := slices.Repeat([]YieldEffect{YieldInvalid}, count)
-	if info != nil {
-		info.YieldEffects = slices.Clone(effects)
-	}
+	info.YieldEffects = slices.Clone(effects)
 	return effects
 }
 
 func (analyzer *effectAnalyzer) cacheExprEffects(expr ast.Expression, effects []YieldEffect) []YieldEffect {
-	info := analyzer.info(expr)
+	info := analyzer.exprInfo(expr)
 	if info == nil || len(effects) != len(info.OutTypes) {
 		return analyzer.invalidExprEffects(expr)
 	}
@@ -143,7 +141,7 @@ func (analyzer *effectAnalyzer) cacheExprEffects(expr ast.Expression, effects []
 }
 
 func (analyzer *effectAnalyzer) deriveExpr(expr ast.Expression) []YieldEffect {
-	info := analyzer.info(expr)
+	info := analyzer.exprInfo(expr)
 	if info == nil || len(info.OutTypes) == 0 || !typesResolved(info.OutTypes) {
 		return analyzer.invalidExprEffects(expr)
 	}
@@ -204,7 +202,7 @@ func alignYieldEffects(effects []YieldEffect, count int) []YieldEffect {
 }
 
 func (analyzer *effectAnalyzer) deriveInfix(expr *ast.InfixExpression) []YieldEffect {
-	info := analyzer.info(expr)
+	info := analyzer.exprInfo(expr)
 	left := analyzer.deriveExpr(expr.Left)
 	right := analyzer.deriveExpr(expr.Right)
 	effects := make([]YieldEffect, len(info.OutTypes))
@@ -243,7 +241,7 @@ func yieldSlot(effects []YieldEffect, index int) YieldEffect {
 }
 
 func (analyzer *effectAnalyzer) deriveCall(expr *ast.CallExpression) []YieldEffect {
-	info := analyzer.info(expr)
+	info := analyzer.exprInfo(expr)
 	invocation := analyzer.callInvocationEffect(expr)
 	if analyzer.expressionDomainMayBeEmpty(expr) {
 		invocation = joinYield(invocation, MayYield)
@@ -274,7 +272,7 @@ func (analyzer *effectAnalyzer) deriveCall(expr *ast.CallExpression) []YieldEffe
 }
 
 func (analyzer *effectAnalyzer) callBodyOutputEffects(expr *ast.CallExpression) []WriteEffect {
-	info := analyzer.info(expr)
+	info := analyzer.exprInfo(expr)
 	mangled := Mangle(analyzer.compiler.MangledPath, expr.Function.Value, info.CallParamTypes)
 	if effects, ok := analyzer.calleeEffects[mangled]; ok {
 		return effects
@@ -290,7 +288,7 @@ func (analyzer *effectAnalyzer) callBodyOutputEffects(expr *ast.CallExpression) 
 }
 
 func (analyzer *effectAnalyzer) expressionDomainMayBeEmpty(expr ast.Expression) bool {
-	info := analyzer.info(expr)
+	info := analyzer.exprInfo(expr)
 	if info == nil {
 		return false
 	}
@@ -304,7 +302,7 @@ func (analyzer *effectAnalyzer) expressionDomainMayBeEmpty(expr ast.Expression) 
 
 func (analyzer *effectAnalyzer) expressionUsesLocalDomain(expr ast.Expression) bool {
 	if call, ok := expr.(*ast.CallExpression); ok {
-		info := analyzer.info(call)
+		info := analyzer.exprInfo(call)
 		if info != nil && info.LoopInside {
 			return false
 		}
@@ -356,7 +354,7 @@ func (analyzer *effectAnalyzer) directCallResolvesSeed(expr ast.Expression, slot
 	if !calleeMaySkip {
 		return false
 	}
-	info := analyzer.info(call)
+	info := analyzer.exprInfo(call)
 	// Direct-return eligibility depends only on output types. Using the shared
 	// ABI predicate avoids tying ReadsSeed to either the range or scalar call
 	// variant selected later by lowering.
@@ -365,7 +363,7 @@ func (analyzer *effectAnalyzer) directCallResolvesSeed(expr ast.Expression, slot
 }
 
 func (analyzer *effectAnalyzer) callOwnsPossiblyEmptyDomain(call *ast.CallExpression) bool {
-	info := analyzer.info(call)
+	info := analyzer.exprInfo(call)
 	if info == nil || !info.LoopInside || !analyzer.expressionDomainMayBeEmpty(call) {
 		return false
 	}

--- a/compiler/effects.go
+++ b/compiler/effects.go
@@ -1,0 +1,676 @@
+package compiler
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/thiremani/pluto/ast"
+)
+
+// WriteEffect describes whether one named target is guaranteed to receive a
+// value. Uncomputed and Invalid are publication states, not lattice members.
+type WriteEffect uint8
+
+const (
+	WriteUncomputed WriteEffect = iota
+	WriteInvalid
+	MustWrite
+	MayWrite
+)
+
+func (effect WriteEffect) String() string {
+	switch effect {
+	case WriteUncomputed:
+		return "Uncomputed"
+	case WriteInvalid:
+		return "Invalid"
+	case MustWrite:
+		return "MustWrite"
+	case MayWrite:
+		return "MayWrite"
+	default:
+		return fmt.Sprintf("WriteEffect(%d)", effect)
+	}
+}
+
+// YieldEffect describes whether one expression outcome is guaranteed to
+// produce a value. Uncomputed and Invalid are publication states, not lattice
+// members.
+type YieldEffect uint8
+
+const (
+	YieldUncomputed YieldEffect = iota
+	YieldInvalid
+	MustYield
+	MayYield
+)
+
+func (effect YieldEffect) String() string {
+	switch effect {
+	case YieldUncomputed:
+		return "Uncomputed"
+	case YieldInvalid:
+		return "Invalid"
+	case MustYield:
+		return "MustYield"
+	case MayYield:
+		return "MayYield"
+	default:
+		return fmt.Sprintf("YieldEffect(%d)", effect)
+	}
+}
+
+// TargetWriteEffect is one entry in a sparse, position-preserving target
+// vector. Discard targets have no entry; TargetIndex keeps later entries tied
+// to their original LHS slots.
+type TargetWriteEffect struct {
+	TargetIndex int
+	Effect      WriteEffect
+}
+
+// StatementEffect contains the target facts derived for one assignment.
+// ReadsSeed holds LHS indices whose existing value is consumed by a direct
+// MayWrite callee output at the assignment boundary.
+type StatementEffect struct {
+	Writes    []TargetWriteEffect
+	ReadsSeed []int
+}
+
+func validPublishedEffects(effects []WriteEffect, count int) bool {
+	if len(effects) != count {
+		return false
+	}
+	for _, effect := range effects {
+		if effect != MustWrite && effect != MayWrite {
+			return false
+		}
+	}
+	return true
+}
+
+func joinYield(left, right YieldEffect) YieldEffect {
+	if left == YieldInvalid || right == YieldInvalid {
+		return YieldInvalid
+	}
+	if left == YieldUncomputed || right == YieldUncomputed {
+		return YieldUncomputed
+	}
+	if left == MayYield || right == MayYield {
+		return MayYield
+	}
+	return MustYield
+}
+
+type effectAnalyzer struct {
+	ts              *TypeSolver
+	funcNameMangled string
+	calleeEffects   map[string][]WriteEffect
+}
+
+func newEffectAnalyzer(ts *TypeSolver, mangled string, calleeEffects map[string][]WriteEffect) *effectAnalyzer {
+	return &effectAnalyzer{
+		ts:              ts,
+		funcNameMangled: mangled,
+		calleeEffects:   calleeEffects,
+	}
+}
+
+func (analyzer *effectAnalyzer) info(expr ast.Expression) *ExprInfo {
+	return analyzer.ts.ExprCache[key(analyzer.funcNameMangled, expr)]
+}
+
+func (analyzer *effectAnalyzer) invalidExprEffects(expr ast.Expression) []YieldEffect {
+	info := analyzer.info(expr)
+	count := 1
+	if info != nil && len(info.OutTypes) > 0 {
+		count = len(info.OutTypes)
+	}
+	effects := slices.Repeat([]YieldEffect{YieldInvalid}, count)
+	if info != nil {
+		info.YieldEffects = slices.Clone(effects)
+	}
+	return effects
+}
+
+func (analyzer *effectAnalyzer) cacheExprEffects(expr ast.Expression, effects []YieldEffect) []YieldEffect {
+	info := analyzer.info(expr)
+	if info == nil || len(effects) != len(info.OutTypes) {
+		return analyzer.invalidExprEffects(expr)
+	}
+	info.YieldEffects = slices.Clone(effects)
+	return effects
+}
+
+func (analyzer *effectAnalyzer) deriveExpr(expr ast.Expression) []YieldEffect {
+	info := analyzer.info(expr)
+	if info == nil || len(info.OutTypes) == 0 || !typesResolved(info.OutTypes) {
+		return analyzer.invalidExprEffects(expr)
+	}
+
+	switch value := expr.(type) {
+	case *ast.IntegerLiteral, *ast.FloatLiteral, *ast.StringLiteral, *ast.Identifier:
+		return analyzer.cacheExprEffects(expr, broadcastYield(MustYield, len(info.OutTypes)))
+	case *ast.ArrayLiteral:
+		analyzer.deriveChildren(expr)
+		return analyzer.cacheExprEffects(expr, broadcastYield(MustYield, len(info.OutTypes)))
+	case *ast.ArrayRangeExpression:
+		analyzer.deriveChildren(expr)
+		return analyzer.cacheExprEffects(expr, broadcastYield(MayYield, len(info.OutTypes)))
+	case *ast.CallExpression:
+		return analyzer.deriveCall(value)
+	case *ast.InfixExpression:
+		return analyzer.deriveInfix(value)
+	case *ast.PrefixExpression:
+		children := analyzer.deriveChildren(expr)
+		return analyzer.cacheExprEffects(expr, alignYieldEffects(children, len(info.OutTypes)))
+	case *ast.DotExpression:
+		children := analyzer.deriveChildren(expr)
+		return analyzer.cacheExprEffects(expr, alignYieldEffects(children, len(info.OutTypes)))
+	case *ast.RangeLiteral, *ast.StructLiteral:
+		children := analyzer.deriveChildren(expr)
+		combined := foldYieldEffects(children)
+		return analyzer.cacheExprEffects(expr, broadcastYield(combined, len(info.OutTypes)))
+	default:
+		return analyzer.invalidExprEffects(expr)
+	}
+}
+
+func (analyzer *effectAnalyzer) deriveChildren(expr ast.Expression) []YieldEffect {
+	var effects []YieldEffect
+	for _, child := range ast.ExprChildren(expr) {
+		effects = append(effects, analyzer.deriveExpr(child)...)
+	}
+	return effects
+}
+
+func foldYieldEffects(effects []YieldEffect) YieldEffect {
+	result := MustYield
+	for _, effect := range effects {
+		result = joinYield(result, effect)
+	}
+	return result
+}
+
+func broadcastYield(effect YieldEffect, count int) []YieldEffect {
+	return slices.Repeat([]YieldEffect{effect}, count)
+}
+
+func alignYieldEffects(effects []YieldEffect, count int) []YieldEffect {
+	if len(effects) == count {
+		return slices.Clone(effects)
+	}
+	return broadcastYield(foldYieldEffects(effects), count)
+}
+
+func (analyzer *effectAnalyzer) deriveInfix(expr *ast.InfixExpression) []YieldEffect {
+	info := analyzer.info(expr)
+	left := analyzer.deriveExpr(expr.Left)
+	right := analyzer.deriveExpr(expr.Right)
+	effects := make([]YieldEffect, len(info.OutTypes))
+	for i := range effects {
+		mode := CondNone
+		if i < len(info.CompareModes) {
+			mode = info.CompareModes[i]
+		}
+		switch mode {
+		case CondScalar, CondAnd:
+			effects[i] = MayYield
+		case CondArray:
+			effects[i] = MustYield
+		case CondOr:
+			effects[i] = yieldSlot(right, i)
+		case CondNone:
+			effects[i] = joinYield(yieldSlot(left, i), yieldSlot(right, i))
+		default:
+			effects[i] = YieldInvalid
+		}
+	}
+	return analyzer.cacheExprEffects(expr, effects)
+}
+
+func yieldSlot(effects []YieldEffect, index int) YieldEffect {
+	if len(effects) == 0 {
+		return YieldInvalid
+	}
+	if len(effects) == 1 {
+		return effects[0]
+	}
+	if index >= len(effects) {
+		return foldYieldEffects(effects)
+	}
+	return effects[index]
+}
+
+func (analyzer *effectAnalyzer) deriveCall(expr *ast.CallExpression) []YieldEffect {
+	info := analyzer.info(expr)
+	invocation := analyzer.callInvocationEffect(expr)
+
+	effects := make([]YieldEffect, len(info.OutTypes))
+	if _, builtin := Builtins[expr.Function.Value]; builtin {
+		for i := range effects {
+			effects[i] = invocation
+		}
+		return analyzer.cacheExprEffects(expr, effects)
+	}
+
+	callee := analyzer.callOutputEffects(expr)
+	if len(callee) != len(effects) {
+		return analyzer.invalidExprEffects(expr)
+	}
+	for i, effect := range callee {
+		if effect == MustWrite {
+			effects[i] = invocation
+		} else if effect == MayWrite {
+			effects[i] = MayYield
+		} else {
+			effects[i] = YieldInvalid
+		}
+	}
+	return analyzer.cacheExprEffects(expr, effects)
+}
+
+func (analyzer *effectAnalyzer) callOutputEffects(expr *ast.CallExpression) []WriteEffect {
+	info := analyzer.info(expr)
+	mangled := Mangle(analyzer.ts.ScriptCompiler.Compiler.MangledPath, expr.Function.Value, info.CallParamTypes)
+	if effects, ok := analyzer.calleeEffects[mangled]; ok {
+		return effects
+	}
+	f := analyzer.ts.ScriptCompiler.Compiler.FuncCache[mangled]
+	if f == nil {
+		panic(fmt.Sprintf("internal: missing callee specialization %s during effect analysis", mangled))
+	}
+	if !f.Settled || !validPublishedEffects(f.OutputEffects, len(f.Sig.OutTypes)) {
+		panic(fmt.Sprintf("internal: read of unpublished effects for %s", mangled))
+	}
+	return f.OutputEffects
+}
+
+func (analyzer *effectAnalyzer) expressionUsesLocalDomain(expr ast.Expression) bool {
+	info := analyzer.info(expr)
+	if info == nil {
+		return false
+	}
+	for _, driver := range info.Ranges {
+		if !rangeLiteralGuaranteedNonEmpty(driver.RangeLit) {
+			return true
+		}
+	}
+	return false
+}
+
+func rangeLiteralGuaranteedNonEmpty(literal *ast.RangeLiteral) bool {
+	if literal == nil {
+		return false
+	}
+	start, startOK := literal.Start.(*ast.IntegerLiteral)
+	stop, stopOK := literal.Stop.(*ast.IntegerLiteral)
+	if !startOK || !stopOK {
+		return false
+	}
+	step := int64(1)
+	if literal.Step != nil {
+		stepLiteral, ok := literal.Step.(*ast.IntegerLiteral)
+		if !ok {
+			return false
+		}
+		step = stepLiteral.Value
+	}
+	return step > 0 && start.Value < stop.Value || step < 0 && start.Value > stop.Value
+}
+
+func (analyzer *effectAnalyzer) callInvocationEffect(expr *ast.CallExpression) YieldEffect {
+	effect := MustYield
+	for _, argument := range expr.Arguments {
+		effect = joinYield(effect, foldYieldEffects(analyzer.deriveExpr(argument)))
+	}
+	return effect
+}
+
+func (analyzer *effectAnalyzer) directCallResolvesSeed(expr ast.Expression, slot int, targetExists bool) bool {
+	call, ok := expr.(*ast.CallExpression)
+	if !ok || !targetExists {
+		return false
+	}
+	if _, builtin := Builtins[call.Function.Value]; builtin {
+		return false
+	}
+	callee := analyzer.callOutputEffects(call)
+	if slot >= len(callee) || callee[slot] != MayWrite {
+		return false
+	}
+	info := analyzer.info(call)
+	// Direct-return eligibility depends only on output types. Using the shared
+	// ABI predicate avoids tying ReadsSeed to either the range or scalar call
+	// variant selected later by lowering.
+	_, direct := directScalarABIReturnType(info.OutTypes)
+	return direct
+}
+
+func (analyzer *effectAnalyzer) deriveStatements(statements []ast.Statement, initiallyDefined map[string]struct{}) map[*ast.LetStatement]StatementEffect {
+	defined := make(map[string]struct{}, len(initiallyDefined))
+	for name := range initiallyDefined {
+		defined[name] = struct{}{}
+	}
+	results := make(map[*ast.LetStatement]StatementEffect)
+	for _, statement := range statements {
+		switch stmt := statement.(type) {
+		case *ast.PrintStatement:
+			for _, argument := range stmt.Expression.Arguments {
+				analyzer.deriveExpr(argument)
+			}
+		case *ast.LetStatement:
+			results[stmt] = analyzer.deriveLet(stmt, defined)
+			for _, target := range stmt.Name {
+				if !isDiscard(target) {
+					defined[target.Value] = struct{}{}
+				}
+			}
+		}
+	}
+	return results
+}
+
+func (analyzer *effectAnalyzer) deriveLet(stmt *ast.LetStatement, defined map[string]struct{}) StatementEffect {
+	for _, condition := range stmt.Condition {
+		analyzer.deriveExpr(condition)
+	}
+
+	result := StatementEffect{}
+	targetIndex := 0
+	for _, expr := range stmt.Value {
+		yields := analyzer.deriveExpr(expr)
+		localDomain := analyzer.expressionUsesLocalDomain(expr)
+		for slot, yield := range yields {
+			if targetIndex >= len(stmt.Name) {
+				return StatementEffect{Writes: []TargetWriteEffect{{TargetIndex: targetIndex, Effect: WriteInvalid}}}
+			}
+			target := stmt.Name[targetIndex]
+			if isDiscard(target) {
+				targetIndex++
+				continue
+			}
+
+			_, targetExists := defined[target.Value]
+			if analyzer.directCallResolvesSeed(expr, slot, targetExists) {
+				result.ReadsSeed = append(result.ReadsSeed, targetIndex)
+				yield = analyzer.callInvocationEffect(expr.(*ast.CallExpression))
+			}
+
+			write := MustWrite
+			if yield != MustYield && yield != MayYield {
+				// Analysis states outside the yield lattice must remain invalid so
+				// function publication cannot turn missing facts into MayWrite.
+				write = WriteInvalid
+			} else if yield == MayYield || len(stmt.Condition) > 0 || localDomain {
+				write = MayWrite
+			}
+			result.Writes = append(result.Writes, TargetWriteEffect{TargetIndex: targetIndex, Effect: write})
+			targetIndex++
+		}
+	}
+	if targetIndex != len(stmt.Name) {
+		return StatementEffect{Writes: []TargetWriteEffect{{TargetIndex: targetIndex, Effect: WriteInvalid}}}
+	}
+	return result
+}
+
+func validStatementEffect(stmt *ast.LetStatement, effect StatementEffect) bool {
+	writeIndex := 0
+	for targetIndex, target := range stmt.Name {
+		if isDiscard(target) {
+			continue
+		}
+		if writeIndex >= len(effect.Writes) {
+			return false
+		}
+		write := effect.Writes[writeIndex]
+		if write.TargetIndex != targetIndex || write.Effect != MustWrite && write.Effect != MayWrite {
+			return false
+		}
+		writeIndex++
+	}
+	if writeIndex != len(effect.Writes) {
+		return false
+	}
+	for _, targetIndex := range effect.ReadsSeed {
+		if targetIndex < 0 || targetIndex >= len(stmt.Name) || isDiscard(stmt.Name[targetIndex]) {
+			return false
+		}
+	}
+	return true
+}
+
+func deriveOutputEffects(template *ast.FuncStatement, statements map[*ast.LetStatement]StatementEffect, hasFunctionDomain bool) []WriteEffect {
+	effects := make([]WriteEffect, len(template.Outputs))
+	for i := range effects {
+		effects[i] = MayWrite
+	}
+	outputIndex := make(map[string]int, len(template.Outputs))
+	for i, output := range template.Outputs {
+		outputIndex[output.Value] = i
+	}
+	for _, statement := range template.Body.Statements {
+		stmt, ok := statement.(*ast.LetStatement)
+		if !ok {
+			continue
+		}
+		statementEffect, exists := statements[stmt]
+		if !exists || !validStatementEffect(stmt, statementEffect) {
+			return slices.Repeat([]WriteEffect{WriteInvalid}, len(template.Outputs))
+		}
+		for _, write := range statementEffect.Writes {
+			index, isOutput := outputIndex[stmt.Name[write.TargetIndex].Value]
+			if isOutput && write.Effect == MustWrite {
+				effects[index] = MustWrite
+			}
+		}
+	}
+	if hasFunctionDomain {
+		for i := range effects {
+			effects[i] = MayWrite
+		}
+	}
+	return effects
+}
+
+type effectNode struct {
+	mangled  string
+	info     *FuncInfo
+	template *ast.FuncStatement
+	edges    []string
+}
+
+type effectGraph struct {
+	nodes map[string]*effectNode
+}
+
+func (ts *TypeSolver) buildEffectGraph(walked map[string]struct{}) *effectGraph {
+	graph := &effectGraph{nodes: make(map[string]*effectNode, len(walked))}
+	for mangled := range walked {
+		f := ts.ScriptCompiler.Compiler.FuncCache[mangled]
+		if f == nil {
+			panic(fmt.Sprintf("internal: missing walked specialization %s", mangled))
+		}
+		template, ok := ts.ScriptCompiler.Compiler.CodeCompiler.lookupFuncTemplate(f.Sig.Name, len(f.Sig.Params))
+		if !ok {
+			panic(fmt.Sprintf("internal: missing template for specialization %s", mangled))
+		}
+		graph.nodes[mangled] = &effectNode{mangled: mangled, info: f, template: template}
+	}
+	for _, node := range graph.nodes {
+		calls := collectBodyCalls(node.template.Body.Statements)
+		for _, call := range calls {
+			if _, builtin := Builtins[call.Function.Value]; builtin {
+				continue
+			}
+			info := ts.ExprCache[key(node.mangled, call)]
+			if info == nil {
+				panic(fmt.Sprintf("internal: missing call facts for %s in specialization %s during effect graph construction", call.Function.Value, node.mangled))
+			}
+			callee := Mangle(ts.ScriptCompiler.Compiler.MangledPath, call.Function.Value, info.CallParamTypes)
+			if _, unsettled := graph.nodes[callee]; unsettled {
+				node.edges = append(node.edges, callee)
+			}
+		}
+		sort.Strings(node.edges)
+		node.edges = slices.Compact(node.edges)
+	}
+	return graph
+}
+
+func collectBodyCalls(statements []ast.Statement) []*ast.CallExpression {
+	var calls []*ast.CallExpression
+	for _, statement := range statements {
+		switch stmt := statement.(type) {
+		case *ast.LetStatement:
+			for _, condition := range stmt.Condition {
+				calls = append(calls, collectExprCalls(condition)...)
+			}
+			for _, value := range stmt.Value {
+				calls = append(calls, collectExprCalls(value)...)
+			}
+		case *ast.PrintStatement:
+			calls = append(calls, collectExprCalls(stmt.Expression)...)
+		}
+	}
+	return calls
+}
+
+func collectExprCalls(expr ast.Expression) []*ast.CallExpression {
+	var calls []*ast.CallExpression
+	if call, ok := expr.(*ast.CallExpression); ok {
+		calls = append(calls, call)
+	}
+	for _, child := range ast.ExprChildren(expr) {
+		calls = append(calls, collectExprCalls(child)...)
+	}
+	return calls
+}
+
+type tarjanState struct {
+	graph      *effectGraph
+	index      int
+	indices    map[string]int
+	lowlink    map[string]int
+	stack      []string
+	onStack    map[string]bool
+	components [][]string
+}
+
+func (graph *effectGraph) calleeFirstComponents() [][]string {
+	state := &tarjanState{
+		graph:   graph,
+		indices: make(map[string]int),
+		lowlink: make(map[string]int),
+		onStack: make(map[string]bool),
+	}
+	names := make([]string, 0, len(graph.nodes))
+	for name := range graph.nodes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if _, visited := state.indices[name]; !visited {
+			state.visit(name)
+		}
+	}
+	return state.components
+}
+
+func (state *tarjanState) visit(name string) {
+	state.index++
+	state.indices[name] = state.index
+	state.lowlink[name] = state.index
+	state.stack = append(state.stack, name)
+	state.onStack[name] = true
+
+	for _, edge := range state.graph.nodes[name].edges {
+		if _, visited := state.indices[edge]; !visited {
+			state.visit(edge)
+			state.lowlink[name] = min(state.lowlink[name], state.lowlink[edge])
+		} else if state.onStack[edge] {
+			state.lowlink[name] = min(state.lowlink[name], state.indices[edge])
+		}
+	}
+	if state.lowlink[name] != state.indices[name] {
+		return
+	}
+
+	var component []string
+	for {
+		last := len(state.stack) - 1
+		member := state.stack[last]
+		state.stack = state.stack[:last]
+		state.onStack[member] = false
+		component = append(component, member)
+		if member == name {
+			break
+		}
+	}
+	sort.Strings(component)
+	state.components = append(state.components, component)
+}
+
+func (ts *TypeSolver) settleEffects(walked map[string]struct{}) {
+	graph := ts.buildEffectGraph(walked)
+	working := make(map[string][]WriteEffect, len(graph.nodes))
+	for name, node := range graph.nodes {
+		working[name] = slices.Repeat([]WriteEffect{MustWrite}, len(node.info.Sig.OutTypes))
+	}
+
+	for _, component := range graph.calleeFirstComponents() {
+		changed := true
+		for changed {
+			changed = false
+			for _, name := range component {
+				node := graph.nodes[name]
+				initial := functionInitialBindings(node.template)
+				analyzer := newEffectAnalyzer(ts, name, working)
+				statements := analyzer.deriveStatements(node.template.Body.Statements, initial)
+				derived := deriveOutputEffects(node.template, statements, node.info.HasFunctionDomain)
+				if !validPublishedEffects(derived, len(node.info.Sig.OutTypes)) {
+					panic(fmt.Sprintf("internal: invalid effects for specialization %s", name))
+				}
+				for i, effect := range derived {
+					if working[name][i] == MustWrite && effect == MayWrite {
+						working[name][i] = MayWrite
+						changed = true
+					}
+				}
+				node.info.StatementEffects = statements
+			}
+		}
+		for _, name := range component {
+			node := graph.nodes[name]
+			node.info.OutputEffects = slices.Clone(working[name])
+		}
+	}
+}
+
+func functionInitialBindings(template *ast.FuncStatement) map[string]struct{} {
+	defined := make(map[string]struct{}, len(template.Parameters)+len(template.Outputs))
+	for _, parameter := range template.Parameters {
+		defined[parameter.Value] = struct{}{}
+	}
+	for _, output := range template.Outputs {
+		defined[output.Value] = struct{}{}
+	}
+	return defined
+}
+
+func (ts *TypeSolver) deriveScriptEffects() {
+	root := ts.ScriptCompiler.Script.Root
+	analyzer := newEffectAnalyzer(ts, ts.ScriptCompiler.ScriptMangled, nil)
+	root.StatementEffects = analyzer.deriveStatements(ts.ScriptCompiler.Program.Statements, nil)
+	for _, statement := range ts.ScriptCompiler.Program.Statements {
+		stmt, ok := statement.(*ast.LetStatement)
+		if !ok {
+			continue
+		}
+		effect, exists := root.StatementEffects[stmt]
+		if !exists || !validStatementEffect(stmt, effect) {
+			panic(fmt.Sprintf("internal: invalid effects for script statement %q", stmt))
+		}
+	}
+}

--- a/compiler/effects.go
+++ b/compiler/effects.go
@@ -103,21 +103,21 @@ func joinYield(left, right YieldEffect) YieldEffect {
 }
 
 type effectAnalyzer struct {
-	ts              *TypeSolver
+	compiler        *Compiler
 	funcNameMangled string
 	calleeEffects   map[string][]WriteEffect
 }
 
-func newEffectAnalyzer(ts *TypeSolver, mangled string, calleeEffects map[string][]WriteEffect) *effectAnalyzer {
+func newEffectAnalyzer(compiler *Compiler, mangled string, calleeEffects map[string][]WriteEffect) *effectAnalyzer {
 	return &effectAnalyzer{
-		ts:              ts,
+		compiler:        compiler,
 		funcNameMangled: mangled,
 		calleeEffects:   calleeEffects,
 	}
 }
 
 func (analyzer *effectAnalyzer) info(expr ast.Expression) *ExprInfo {
-	return analyzer.ts.ExprCache[key(analyzer.funcNameMangled, expr)]
+	return analyzer.compiler.ExprCache[key(analyzer.funcNameMangled, expr)]
 }
 
 func (analyzer *effectAnalyzer) invalidExprEffects(expr ast.Expression) []YieldEffect {
@@ -275,11 +275,11 @@ func (analyzer *effectAnalyzer) deriveCall(expr *ast.CallExpression) []YieldEffe
 
 func (analyzer *effectAnalyzer) callBodyOutputEffects(expr *ast.CallExpression) []WriteEffect {
 	info := analyzer.info(expr)
-	mangled := Mangle(analyzer.ts.ScriptCompiler.Compiler.MangledPath, expr.Function.Value, info.CallParamTypes)
+	mangled := Mangle(analyzer.compiler.MangledPath, expr.Function.Value, info.CallParamTypes)
 	if effects, ok := analyzer.calleeEffects[mangled]; ok {
 		return effects
 	}
-	f := analyzer.ts.ScriptCompiler.Compiler.FuncCache[mangled]
+	f := analyzer.compiler.FuncCache[mangled]
 	if f == nil {
 		panic(fmt.Sprintf("internal: missing callee specialization %s during effect analysis", mangled))
 	}
@@ -651,7 +651,7 @@ func (ts *TypeSolver) settleEffects(walked map[string]struct{}) {
 			for _, name := range component {
 				node := graph.nodes[name]
 				initial := functionInitialBindings(node.template)
-				analyzer := newEffectAnalyzer(ts, name, working)
+				analyzer := newEffectAnalyzer(ts.ScriptCompiler.Compiler, name, working)
 				statements := analyzer.deriveStatements(node.template.Body.Statements, initial)
 				derived := deriveBodyOutputEffects(node.template, statements)
 				if !validPublishedEffects(derived, len(node.info.Sig.OutTypes)) {
@@ -686,7 +686,7 @@ func functionInitialBindings(template *ast.FuncStatement) map[string]struct{} {
 
 func (ts *TypeSolver) deriveScriptEffects() {
 	root := ts.ScriptCompiler.Script.Root
-	analyzer := newEffectAnalyzer(ts, ts.ScriptCompiler.ScriptMangled, nil)
+	analyzer := newEffectAnalyzer(ts.ScriptCompiler.Compiler, ts.ScriptCompiler.ScriptMangled, nil)
 	root.StatementEffects = analyzer.deriveStatements(ts.ScriptCompiler.Program.Statements, nil)
 	for _, statement := range ts.ScriptCompiler.Program.Statements {
 		stmt, ok := statement.(*ast.LetStatement)

--- a/compiler/effects.go
+++ b/compiler/effects.go
@@ -245,6 +245,9 @@ func yieldSlot(effects []YieldEffect, index int) YieldEffect {
 func (analyzer *effectAnalyzer) deriveCall(expr *ast.CallExpression) []YieldEffect {
 	info := analyzer.info(expr)
 	invocation := analyzer.callInvocationEffect(expr)
+	if analyzer.expressionDomainMayBeEmpty(expr) {
+		invocation = joinYield(invocation, MayYield)
+	}
 
 	effects := make([]YieldEffect, len(info.OutTypes))
 	if _, builtin := Builtins[expr.Function.Value]; builtin {
@@ -254,7 +257,7 @@ func (analyzer *effectAnalyzer) deriveCall(expr *ast.CallExpression) []YieldEffe
 		return analyzer.cacheExprEffects(expr, effects)
 	}
 
-	callee := analyzer.callOutputEffects(expr)
+	callee := analyzer.callBodyOutputEffects(expr)
 	if len(callee) != len(effects) {
 		return analyzer.invalidExprEffects(expr)
 	}
@@ -270,7 +273,7 @@ func (analyzer *effectAnalyzer) deriveCall(expr *ast.CallExpression) []YieldEffe
 	return analyzer.cacheExprEffects(expr, effects)
 }
 
-func (analyzer *effectAnalyzer) callOutputEffects(expr *ast.CallExpression) []WriteEffect {
+func (analyzer *effectAnalyzer) callBodyOutputEffects(expr *ast.CallExpression) []WriteEffect {
 	info := analyzer.info(expr)
 	mangled := Mangle(analyzer.ts.ScriptCompiler.Compiler.MangledPath, expr.Function.Value, info.CallParamTypes)
 	if effects, ok := analyzer.calleeEffects[mangled]; ok {
@@ -280,13 +283,13 @@ func (analyzer *effectAnalyzer) callOutputEffects(expr *ast.CallExpression) []Wr
 	if f == nil {
 		panic(fmt.Sprintf("internal: missing callee specialization %s during effect analysis", mangled))
 	}
-	if !f.Settled || !validPublishedEffects(f.OutputEffects, len(f.Sig.OutTypes)) {
+	if !f.Settled || !validPublishedEffects(f.BodyOutputEffects, len(f.Sig.OutTypes)) {
 		panic(fmt.Sprintf("internal: read of unpublished effects for %s", mangled))
 	}
-	return f.OutputEffects
+	return f.BodyOutputEffects
 }
 
-func (analyzer *effectAnalyzer) expressionUsesLocalDomain(expr ast.Expression) bool {
+func (analyzer *effectAnalyzer) expressionDomainMayBeEmpty(expr ast.Expression) bool {
 	info := analyzer.info(expr)
 	if info == nil {
 		return false
@@ -297,6 +300,16 @@ func (analyzer *effectAnalyzer) expressionUsesLocalDomain(expr ast.Expression) b
 		}
 	}
 	return false
+}
+
+func (analyzer *effectAnalyzer) expressionUsesLocalDomain(expr ast.Expression) bool {
+	if call, ok := expr.(*ast.CallExpression); ok {
+		info := analyzer.info(call)
+		if info != nil && info.LoopInside {
+			return false
+		}
+	}
+	return analyzer.expressionDomainMayBeEmpty(expr)
 }
 
 func rangeLiteralGuaranteedNonEmpty(literal *ast.RangeLiteral) bool {
@@ -335,8 +348,12 @@ func (analyzer *effectAnalyzer) directCallResolvesSeed(expr ast.Expression, slot
 	if _, builtin := Builtins[call.Function.Value]; builtin {
 		return false
 	}
-	callee := analyzer.callOutputEffects(call)
-	if slot >= len(callee) || callee[slot] != MayWrite {
+	callee := analyzer.callBodyOutputEffects(call)
+	if slot >= len(callee) {
+		return false
+	}
+	calleeMaySkip := callee[slot] == MayWrite || analyzer.callOwnsPossiblyEmptyDomain(call)
+	if !calleeMaySkip {
 		return false
 	}
 	info := analyzer.info(call)
@@ -345,6 +362,19 @@ func (analyzer *effectAnalyzer) directCallResolvesSeed(expr ast.Expression, slot
 	// variant selected later by lowering.
 	_, direct := directScalarABIReturnType(info.OutTypes)
 	return direct
+}
+
+func (analyzer *effectAnalyzer) callOwnsPossiblyEmptyDomain(call *ast.CallExpression) bool {
+	info := analyzer.info(call)
+	if info == nil || !info.LoopInside || !analyzer.expressionDomainMayBeEmpty(call) {
+		return false
+	}
+	for _, paramType := range info.CallParamTypes {
+		if paramType.Kind() == RangeKind || paramType.Kind() == ArrayRangeKind {
+			return true
+		}
+	}
+	return false
 }
 
 func (analyzer *effectAnalyzer) deriveStatements(statements []ast.Statement, initiallyDefined map[string]struct{}) map[*ast.LetStatement]StatementEffect {
@@ -441,7 +471,7 @@ func validStatementEffect(stmt *ast.LetStatement, effect StatementEffect) bool {
 	return true
 }
 
-func deriveOutputEffects(template *ast.FuncStatement, statements map[*ast.LetStatement]StatementEffect, hasFunctionDomain bool) []WriteEffect {
+func deriveBodyOutputEffects(template *ast.FuncStatement, statements map[*ast.LetStatement]StatementEffect) []WriteEffect {
 	effects := make([]WriteEffect, len(template.Outputs))
 	for i := range effects {
 		effects[i] = MayWrite
@@ -464,11 +494,6 @@ func deriveOutputEffects(template *ast.FuncStatement, statements map[*ast.LetSta
 			if isOutput && write.Effect == MustWrite {
 				effects[index] = MustWrite
 			}
-		}
-	}
-	if hasFunctionDomain {
-		for i := range effects {
-			effects[i] = MayWrite
 		}
 	}
 	return effects
@@ -628,7 +653,7 @@ func (ts *TypeSolver) settleEffects(walked map[string]struct{}) {
 				initial := functionInitialBindings(node.template)
 				analyzer := newEffectAnalyzer(ts, name, working)
 				statements := analyzer.deriveStatements(node.template.Body.Statements, initial)
-				derived := deriveOutputEffects(node.template, statements, node.info.HasFunctionDomain)
+				derived := deriveBodyOutputEffects(node.template, statements)
 				if !validPublishedEffects(derived, len(node.info.Sig.OutTypes)) {
 					panic(fmt.Sprintf("internal: invalid effects for specialization %s", name))
 				}
@@ -643,7 +668,7 @@ func (ts *TypeSolver) settleEffects(walked map[string]struct{}) {
 		}
 		for _, name := range component {
 			node := graph.nodes[name]
-			node.info.OutputEffects = slices.Clone(working[name])
+			node.info.BodyOutputEffects = slices.Clone(working[name])
 		}
 	}
 }

--- a/compiler/effects_test.go
+++ b/compiler/effects_test.go
@@ -83,14 +83,17 @@ y = Maybe(x)
 	ts := solveScriptTypes(t, ctx, cc, t.Name(), `existing = 7
 existing = Maybe(1)
 fresh = Maybe(1)
+alwaysExisting = 4
+alwaysExisting = Always(1)
 arr = [1]
 other = 9
 other = Always(arr[2])
-existing, other`)
+existing, alwaysExisting, other`)
 	program := ts.ScriptCompiler.Program
 	resolved := program.Statements[1].(*ast.LetStatement)
 	fresh := program.Statements[2].(*ast.LetStatement)
-	callerFailure := program.Statements[5].(*ast.LetStatement)
+	alwaysResolved := program.Statements[4].(*ast.LetStatement)
+	callerFailure := program.Statements[7].(*ast.LetStatement)
 
 	resolvedEffect := ts.ScriptCompiler.Script.Root.StatementEffects[resolved]
 	requireTargetEffects(t, resolvedEffect, TargetWriteEffect{TargetIndex: 0, Effect: MustWrite})
@@ -101,43 +104,90 @@ existing, other`)
 	requireTargetEffects(t, freshEffect, TargetWriteEffect{TargetIndex: 0, Effect: MayWrite})
 	require.Empty(t, freshEffect.ReadsSeed)
 
+	alwaysResolvedEffect := ts.ScriptCompiler.Script.Root.StatementEffects[alwaysResolved]
+	requireTargetEffects(t, alwaysResolvedEffect, TargetWriteEffect{TargetIndex: 0, Effect: MustWrite})
+	require.Empty(t, alwaysResolvedEffect.ReadsSeed)
+
 	callerFailureEffect := ts.ScriptCompiler.Script.Root.StatementEffects[callerFailure]
 	requireTargetEffects(t, callerFailureEffect, TargetWriteEffect{TargetIndex: 0, Effect: MayWrite})
 	require.Empty(t, callerFailureEffect.ReadsSeed)
 
 	maybe := cc.Compiler.FuncCache[Mangle(cc.Compiler.MangledPath, "Maybe", []Type{I64})]
 	always := cc.Compiler.FuncCache[Mangle(cc.Compiler.MangledPath, "Always", []Type{I64})]
-	require.Equal(t, []WriteEffect{MayWrite}, maybe.OutputEffects)
-	require.Equal(t, []WriteEffect{MustWrite}, always.OutputEffects)
+	require.Equal(t, []WriteEffect{MayWrite}, maybe.BodyOutputEffects)
+	require.Equal(t, []WriteEffect{MustWrite}, always.BodyOutputEffects)
 	require.True(t, maybe.Settled)
 	require.True(t, always.Settled)
 }
 
-func TestFunctionDomainWeakensOnlyPublishedOutput(t *testing.T) {
+func TestCallDomainComposesWithBodyOutputEffects(t *testing.T) {
 	ctx := llvm.NewContext()
 	defer ctx.Dispose()
 	cc := NewCodeCompiler(ctx, "domainEffects", "", mustParseCode(t, `y = Increment(x)
     y = x + 1`))
 	require.Empty(t, cc.Compile())
 
-	ts := solveScriptTypes(t, ctx, cc, t.Name(), `result = Increment(0:0)
-result`)
+	ts := solveScriptTypes(t, ctx, cc, t.Name(), `existing = 9
+existing = Increment(0:0)
+empty = Increment(0:0)
+nonempty = Increment(0:2)
+existing, empty, nonempty`)
 	mangled := Mangle(cc.Compiler.MangledPath, "Increment", []Type{Range{Iter: I64}})
 	increment := cc.Compiler.FuncCache[mangled]
 	require.NotNil(t, increment)
-	require.True(t, increment.HasFunctionDomain)
-	require.Equal(t, []WriteEffect{MayWrite}, increment.OutputEffects)
+	require.Equal(t, []WriteEffect{MustWrite}, increment.BodyOutputEffects)
 
 	template, ok := cc.lookupFuncTemplate("Increment", 1)
 	require.True(t, ok)
 	bodyStmt := template.Body.Statements[0].(*ast.LetStatement)
 	requireTargetEffects(t, increment.StatementEffects[bodyStmt], TargetWriteEffect{TargetIndex: 0, Effect: MustWrite})
 
-	callStmt := ts.ScriptCompiler.Program.Statements[0].(*ast.LetStatement)
-	requireTargetEffects(t, ts.ScriptCompiler.Script.Root.StatementEffects[callStmt], TargetWriteEffect{TargetIndex: 0, Effect: MayWrite})
+	existing := ts.ScriptCompiler.Program.Statements[1].(*ast.LetStatement)
+	existingEffect := ts.ScriptCompiler.Script.Root.StatementEffects[existing]
+	requireTargetEffects(t, existingEffect, TargetWriteEffect{TargetIndex: 0, Effect: MustWrite})
+	require.Equal(t, []int{0}, existingEffect.ReadsSeed)
+
+	empty := ts.ScriptCompiler.Program.Statements[2].(*ast.LetStatement)
+	emptyEffect := ts.ScriptCompiler.Script.Root.StatementEffects[empty]
+	requireTargetEffects(t, emptyEffect, TargetWriteEffect{TargetIndex: 0, Effect: MayWrite})
+	require.Empty(t, emptyEffect.ReadsSeed)
+	require.Equal(t, []YieldEffect{MayYield}, ts.ExprCache[key(ts.FuncNameMangled, empty.Value[0])].YieldEffects)
+
+	nonempty := ts.ScriptCompiler.Program.Statements[3].(*ast.LetStatement)
+	nonemptyEffect := ts.ScriptCompiler.Script.Root.StatementEffects[nonempty]
+	requireTargetEffects(t, nonemptyEffect, TargetWriteEffect{TargetIndex: 0, Effect: MustWrite})
+	require.Empty(t, nonemptyEffect.ReadsSeed)
+	require.Equal(t, []YieldEffect{MustYield}, ts.ExprCache[key(ts.FuncNameMangled, nonempty.Value[0])].YieldEffects)
 }
 
-func TestRecursiveOutputEffectsConvergeAcrossSCC(t *testing.T) {
+func TestConditionalBodyRemainsMayWriteAcrossNonemptyDomain(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	cc := NewCodeCompiler(ctx, "conditionalDomainEffects", "", mustParseCode(t, `y = ConditionalSquare(x)
+    y = x > 5 x * x`))
+	require.Empty(t, cc.Compile())
+
+	ts := solveScriptTypes(t, ctx, cc, t.Name(), `fresh = ConditionalSquare(0:5)
+existing = 9
+existing = ConditionalSquare(0:5)
+fresh, existing`)
+	mangled := Mangle(cc.Compiler.MangledPath, "ConditionalSquare", []Type{Range{Iter: I64}})
+	conditional := cc.Compiler.FuncCache[mangled]
+	require.NotNil(t, conditional)
+	require.Equal(t, []WriteEffect{MayWrite}, conditional.BodyOutputEffects)
+
+	fresh := ts.ScriptCompiler.Program.Statements[0].(*ast.LetStatement)
+	freshEffect := ts.ScriptCompiler.Script.Root.StatementEffects[fresh]
+	requireTargetEffects(t, freshEffect, TargetWriteEffect{TargetIndex: 0, Effect: MayWrite})
+	require.Empty(t, freshEffect.ReadsSeed)
+
+	existing := ts.ScriptCompiler.Program.Statements[2].(*ast.LetStatement)
+	existingEffect := ts.ScriptCompiler.Script.Root.StatementEffects[existing]
+	requireTargetEffects(t, existingEffect, TargetWriteEffect{TargetIndex: 0, Effect: MustWrite})
+	require.Equal(t, []int{0}, existingEffect.ReadsSeed)
+}
+
+func TestRecursiveBodyOutputEffectsConvergeAcrossSCC(t *testing.T) {
 	ctx := llvm.NewContext()
 	defer ctx.Dispose()
 	cc := NewCodeCompiler(ctx, "recursiveEffects", "", mustParseCode(t, `y = A(n)
@@ -152,8 +202,8 @@ y = B(n)
 result`)
 	a := cc.Compiler.FuncCache[Mangle(cc.Compiler.MangledPath, "A", []Type{I64})]
 	b := cc.Compiler.FuncCache[Mangle(cc.Compiler.MangledPath, "B", []Type{I64})]
-	require.Equal(t, []WriteEffect{MayWrite}, a.OutputEffects)
-	require.Equal(t, []WriteEffect{MayWrite}, b.OutputEffects)
+	require.Equal(t, []WriteEffect{MayWrite}, a.BodyOutputEffects)
+	require.Equal(t, []WriteEffect{MayWrite}, b.BodyOutputEffects)
 	require.True(t, a.Settled)
 	require.True(t, b.Settled)
 }

--- a/compiler/effects_test.go
+++ b/compiler/effects_test.go
@@ -1,0 +1,203 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thiremani/pluto/ast"
+	"tinygo.org/x/go-llvm"
+)
+
+func requireTargetEffects(t *testing.T, effect StatementEffect, expected ...TargetWriteEffect) {
+	t.Helper()
+	require.Equal(t, expected, effect.Writes)
+}
+
+func TestStatementEffectsStayAlignedAcrossMixedRHSAndDiscard(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	cc := NewCodeCompiler(ctx, "mixedEffects", "", mustParseCode(t, ""))
+	require.Empty(t, cc.Compile())
+
+	ts := solveScriptTypes(t, ctx, cc, t.Name(), `arr = [10 20]
+i = 0
+x, _, y = arr[i], arr[i], i + 1
+x, y`)
+	stmt := ts.ScriptCompiler.Program.Statements[2].(*ast.LetStatement)
+	effect := ts.ScriptCompiler.Script.Root.StatementEffects[stmt]
+	requireTargetEffects(t, effect,
+		TargetWriteEffect{TargetIndex: 0, Effect: MayWrite},
+		TargetWriteEffect{TargetIndex: 2, Effect: MustWrite},
+	)
+	require.Empty(t, effect.ReadsSeed)
+
+	firstAccess := stmt.Value[0].(*ast.ArrayRangeExpression)
+	secondAccess := stmt.Value[1].(*ast.ArrayRangeExpression)
+	require.Equal(t, []YieldEffect{MayYield}, ts.ExprCache[key(ts.FuncNameMangled, firstAccess)].YieldEffects)
+	require.Equal(t, []YieldEffect{MayYield}, ts.ExprCache[key(ts.FuncNameMangled, secondAccess)].YieldEffects)
+	require.Equal(t, []YieldEffect{MustYield}, ts.ExprCache[key(ts.FuncNameMangled, stmt.Value[2])].YieldEffects)
+}
+
+func TestFallbackYieldEffectUsesFinalAlternative(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	cc := NewCodeCompiler(ctx, "fallbackEffects", "", mustParseCode(t, ""))
+	require.Empty(t, cc.Compile())
+
+	ts := solveScriptTypes(t, ctx, cc, t.Name(), `resolved = 1 > 0 || 2
+unresolved = 1 > 0 || 2 > 0
+resolved, unresolved`)
+	resolved := ts.ScriptCompiler.Program.Statements[0].(*ast.LetStatement)
+	unresolved := ts.ScriptCompiler.Program.Statements[1].(*ast.LetStatement)
+	requireTargetEffects(t, ts.ScriptCompiler.Script.Root.StatementEffects[resolved], TargetWriteEffect{TargetIndex: 0, Effect: MustWrite})
+	requireTargetEffects(t, ts.ScriptCompiler.Script.Root.StatementEffects[unresolved], TargetWriteEffect{TargetIndex: 0, Effect: MayWrite})
+	require.Equal(t, []YieldEffect{MustYield}, ts.ExprCache[key(ts.FuncNameMangled, resolved.Value[0])].YieldEffects)
+	require.Equal(t, []YieldEffect{MayYield}, ts.ExprCache[key(ts.FuncNameMangled, unresolved.Value[0])].YieldEffects)
+}
+
+func TestLiteralDomainEffectUsesProvableEmptiness(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	cc := NewCodeCompiler(ctx, "literalDomainEffects", "", mustParseCode(t, ""))
+	require.Empty(t, cc.Compile())
+
+	ts := solveScriptTypes(t, ctx, cc, t.Name(), `nonempty = 5 + 1:3
+empty = 5 + 0:0
+nonempty, empty`)
+	nonempty := ts.ScriptCompiler.Program.Statements[0].(*ast.LetStatement)
+	empty := ts.ScriptCompiler.Program.Statements[1].(*ast.LetStatement)
+	requireTargetEffects(t, ts.ScriptCompiler.Script.Root.StatementEffects[nonempty], TargetWriteEffect{TargetIndex: 0, Effect: MustWrite})
+	requireTargetEffects(t, ts.ScriptCompiler.Script.Root.StatementEffects[empty], TargetWriteEffect{TargetIndex: 0, Effect: MayWrite})
+}
+
+func TestDirectCallSeedResolutionIsSeparateFromInvocationFailure(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	cc := NewCodeCompiler(ctx, "callEffects", "", mustParseCode(t, `y = Always(x)
+    y = x
+
+y = Maybe(x)
+    y = x > 0 x`))
+	require.Empty(t, cc.Compile())
+
+	ts := solveScriptTypes(t, ctx, cc, t.Name(), `existing = 7
+existing = Maybe(1)
+fresh = Maybe(1)
+arr = [1]
+other = 9
+other = Always(arr[2])
+existing, other`)
+	program := ts.ScriptCompiler.Program
+	resolved := program.Statements[1].(*ast.LetStatement)
+	fresh := program.Statements[2].(*ast.LetStatement)
+	callerFailure := program.Statements[5].(*ast.LetStatement)
+
+	resolvedEffect := ts.ScriptCompiler.Script.Root.StatementEffects[resolved]
+	requireTargetEffects(t, resolvedEffect, TargetWriteEffect{TargetIndex: 0, Effect: MustWrite})
+	require.Equal(t, []int{0}, resolvedEffect.ReadsSeed)
+	require.Equal(t, []YieldEffect{MayYield}, ts.ExprCache[key(ts.FuncNameMangled, resolved.Value[0])].YieldEffects)
+
+	freshEffect := ts.ScriptCompiler.Script.Root.StatementEffects[fresh]
+	requireTargetEffects(t, freshEffect, TargetWriteEffect{TargetIndex: 0, Effect: MayWrite})
+	require.Empty(t, freshEffect.ReadsSeed)
+
+	callerFailureEffect := ts.ScriptCompiler.Script.Root.StatementEffects[callerFailure]
+	requireTargetEffects(t, callerFailureEffect, TargetWriteEffect{TargetIndex: 0, Effect: MayWrite})
+	require.Empty(t, callerFailureEffect.ReadsSeed)
+
+	maybe := cc.Compiler.FuncCache[Mangle(cc.Compiler.MangledPath, "Maybe", []Type{I64})]
+	always := cc.Compiler.FuncCache[Mangle(cc.Compiler.MangledPath, "Always", []Type{I64})]
+	require.Equal(t, []WriteEffect{MayWrite}, maybe.OutputEffects)
+	require.Equal(t, []WriteEffect{MustWrite}, always.OutputEffects)
+	require.True(t, maybe.Settled)
+	require.True(t, always.Settled)
+}
+
+func TestFunctionDomainWeakensOnlyPublishedOutput(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	cc := NewCodeCompiler(ctx, "domainEffects", "", mustParseCode(t, `y = Increment(x)
+    y = x + 1`))
+	require.Empty(t, cc.Compile())
+
+	ts := solveScriptTypes(t, ctx, cc, t.Name(), `result = Increment(0:0)
+result`)
+	mangled := Mangle(cc.Compiler.MangledPath, "Increment", []Type{Range{Iter: I64}})
+	increment := cc.Compiler.FuncCache[mangled]
+	require.NotNil(t, increment)
+	require.True(t, increment.HasFunctionDomain)
+	require.Equal(t, []WriteEffect{MayWrite}, increment.OutputEffects)
+
+	template, ok := cc.lookupFuncTemplate("Increment", 1)
+	require.True(t, ok)
+	bodyStmt := template.Body.Statements[0].(*ast.LetStatement)
+	requireTargetEffects(t, increment.StatementEffects[bodyStmt], TargetWriteEffect{TargetIndex: 0, Effect: MustWrite})
+
+	callStmt := ts.ScriptCompiler.Program.Statements[0].(*ast.LetStatement)
+	requireTargetEffects(t, ts.ScriptCompiler.Script.Root.StatementEffects[callStmt], TargetWriteEffect{TargetIndex: 0, Effect: MayWrite})
+}
+
+func TestRecursiveOutputEffectsConvergeAcrossSCC(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	cc := NewCodeCompiler(ctx, "recursiveEffects", "", mustParseCode(t, `y = A(n)
+    y = B(n)
+
+y = B(n)
+    y = n > 0 A(n - 1)
+    y = n == 0 "done"`))
+	require.Empty(t, cc.Compile())
+
+	solveScriptTypes(t, ctx, cc, t.Name(), `result = A(2)
+result`)
+	a := cc.Compiler.FuncCache[Mangle(cc.Compiler.MangledPath, "A", []Type{I64})]
+	b := cc.Compiler.FuncCache[Mangle(cc.Compiler.MangledPath, "B", []Type{I64})]
+	require.Equal(t, []WriteEffect{MayWrite}, a.OutputEffects)
+	require.Equal(t, []WriteEffect{MayWrite}, b.OutputEffects)
+	require.True(t, a.Settled)
+	require.True(t, b.Settled)
+}
+
+func TestEffectGraphRejectsMissingCallFacts(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	cc := NewCodeCompiler(ctx, "missingCallEffects", "", mustParseCode(t, `y = Outer(x)
+    y = Inner(x)
+
+y = Inner(x)
+    y = x`))
+	require.Empty(t, cc.Compile())
+
+	ts := solveScriptTypes(t, ctx, cc, t.Name(), `result = Outer(1)
+result`)
+	outerMangled := Mangle(cc.Compiler.MangledPath, "Outer", []Type{I64})
+	innerMangled := Mangle(cc.Compiler.MangledPath, "Inner", []Type{I64})
+	outerTemplate, ok := cc.lookupFuncTemplate("Outer", 1)
+	require.True(t, ok)
+	call := outerTemplate.Body.Statements[0].(*ast.LetStatement).Value[0].(*ast.CallExpression)
+	delete(ts.ExprCache, key(outerMangled, call))
+
+	require.PanicsWithValue(t,
+		"internal: missing call facts for Inner in specialization "+outerMangled+" during effect graph construction",
+		func() {
+			ts.buildEffectGraph(map[string]struct{}{outerMangled: {}, innerMangled: {}})
+		},
+	)
+}
+
+func TestScriptEffectsRejectInvalidExpressionFacts(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	cc := NewCodeCompiler(ctx, "invalidScriptEffects", "", mustParseCode(t, ""))
+	require.Empty(t, cc.Compile())
+
+	ts := solveScriptTypes(t, ctx, cc, t.Name(), `value = 1
+value`)
+	stmt := ts.ScriptCompiler.Program.Statements[0].(*ast.LetStatement)
+	delete(ts.ExprCache, key(ts.FuncNameMangled, stmt.Value[0]))
+
+	require.PanicsWithValue(t,
+		`internal: invalid effects for script statement "value = 1"`,
+		ts.deriveScriptEffects,
+	)
+}

--- a/compiler/scriptcompiler.go
+++ b/compiler/scriptcompiler.go
@@ -23,8 +23,9 @@ func NewScriptCompiler(ctx llvm.Context, name string, program *ast.Program, cc *
 	script := &Script{
 		Name: name,
 		Root: &FuncInfo{
-			Sig:  Func{Name: name},
-			Vars: make(map[string]Type),
+			Sig:              Func{Name: name},
+			Vars:             make(map[string]Type),
+			StatementEffects: make(map[*ast.LetStatement]StatementEffect),
 		},
 	}
 	scriptMangled := MangleScript(cc.Compiler.MangledPath, name)

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -31,13 +31,14 @@ type ExprInfo struct {
 	Rewrite              ast.Expression // expression rewritten with a literal -> compiler-local value, e.g. (0:11) -> $ts_iter_0.
 	ExprLen              int
 	OutTypes             []Type
-	HasRanges            bool       // True if expression involves ranges (propagated upward during typing)
-	LoopInside           bool       // For CallExpression: true if function handles iteration, false if call site handles it
-	CallParamTypes       []Type     // Solver-selected call params for the original expression shape
-	ScalarCallParamTypes []Type     // Param types to use once outer loops consume ranges into scalars
-	CompareModes         []CondMode // Per-slot lowering mode for comparisons in value position (nil for non-comparisons)
-	ArrayShape           []uint64   // Statically known dimensions for array literals; nil when runtime-dependent
-	RangeDriverCond      bool       // Solver-classified loop-domain condition; true implies len(Ranges) > 0.
+	HasRanges            bool          // True if expression involves ranges (propagated upward during typing)
+	LoopInside           bool          // For CallExpression: true if function handles iteration, false if call site handles it
+	CallParamTypes       []Type        // Solver-selected call params for the original expression shape
+	ScalarCallParamTypes []Type        // Param types to use once outer loops consume ranges into scalars
+	CompareModes         []CondMode    // Per-slot lowering mode for comparisons in value position (nil for non-comparisons)
+	ArrayShape           []uint64      // Statically known dimensions for array literals; nil when runtime-dependent
+	RangeDriverCond      bool          // Solver-classified loop-domain condition; true implies len(Ranges) > 0.
+	YieldEffects         []YieldEffect // Per-output production guarantee, derived after types settle.
 }
 
 // HasCondScalar returns true if any slot is a scalar conditional expression.
@@ -708,6 +709,9 @@ func (ts *TypeSolver) Solve() {
 			Msg:   fmt.Sprintf("type for %q could not be resolved", pending.name),
 		})
 	}
+	if len(ts.Errors) == 0 {
+		ts.deriveScriptEffects()
+	}
 }
 
 // TypePrintStatement types a print in value position: a comparison yields its
@@ -751,7 +755,7 @@ func (ts *TypeSolver) ensureScalarCallVariant(ce *ast.CallExpression) {
 	// Look up and create the scalar variant
 	template, mangled, ok := ts.lookupCallTemplate(ce, scalarArgs)
 	if ok {
-		ts.InferFuncTypes(ce, scalarArgs, mangled, template)
+		ts.InferFuncTypes(ce, scalarArgs, scalarArgs, mangled, template)
 	}
 }
 
@@ -2268,7 +2272,7 @@ func (ts *TypeSolver) TypeCallExpression(ce *ast.CallExpression, isRoot bool) []
 		return info.OutTypes
 	}
 
-	f := ts.InferFuncTypes(ce, innerArgs, mangled, template)
+	f := ts.InferFuncTypes(ce, innerArgs, args, mangled, template)
 	info.OutTypes = append([]Type(nil), f.Sig.OutTypes...)
 	info.ExprLen = len(info.OutTypes)
 	info.HasRanges = hasRanges
@@ -2443,14 +2447,17 @@ func (ts *TypeSolver) lookupCallTemplate(ce *ast.CallExpression, args []Type) (*
 // newFunc creates and caches a specialization record for the call.
 // String params keep their StrG/StrH type - functions are mangled separately for each.
 // Cache before inference so recursive calls can reuse the partial specialization.
-func (ts *TypeSolver) newFunc(ce *ast.CallExpression, args []Type, mangled string, template *ast.FuncStatement) *FuncInfo {
+func (ts *TypeSolver) newFunc(ce *ast.CallExpression, bodyArgs, callArgs []Type, mangled string, template *ast.FuncStatement) *FuncInfo {
 	f := &FuncInfo{
 		Sig: Func{
 			Name:     ce.Function.Value,
-			Params:   args,
+			Params:   bodyArgs,
 			OutTypes: make([]Type, len(template.Outputs)),
 		},
-		Vars: make(map[string]Type),
+		Vars:              make(map[string]Type),
+		StatementEffects:  make(map[*ast.LetStatement]StatementEffect),
+		OutputEffects:     slices.Repeat([]WriteEffect{WriteUncomputed}, len(template.Outputs)),
+		HasFunctionDomain: hasFunctionDomain(callArgs),
 	}
 	for i := range f.Sig.OutTypes {
 		f.Sig.OutTypes[i] = Unresolved{}
@@ -2459,13 +2466,22 @@ func (ts *TypeSolver) newFunc(ce *ast.CallExpression, args []Type, mangled strin
 	return f
 }
 
-func (ts *TypeSolver) InferFuncTypes(ce *ast.CallExpression, args []Type, mangled string, template *ast.FuncStatement) *FuncInfo {
+func hasFunctionDomain(types []Type) bool {
+	for _, typ := range types {
+		if typ.Kind() == RangeKind || typ.Kind() == ArrayRangeKind {
+			return true
+		}
+	}
+	return false
+}
+
+func (ts *TypeSolver) InferFuncTypes(ce *ast.CallExpression, bodyArgs, callArgs []Type, mangled string, template *ast.FuncStatement) *FuncInfo {
 	// Fetch existing func cache entry (if any).
 	f, ok := ts.ScriptCompiler.Compiler.FuncCache[mangled]
 
 	// Create new Func if not cached (ok means recursive/previously seen call, reuse f)
 	if !ok {
-		f = ts.newFunc(ce, args, mangled, template)
+		f = ts.newFunc(ce, bodyArgs, callArgs, mangled, template)
 	}
 
 	// Inside a function - unresolved args are allowed (resolved in later passes)
@@ -2478,7 +2494,7 @@ func (ts *TypeSolver) InferFuncTypes(ce *ast.CallExpression, args []Type, mangle
 	}
 
 	// At script level, all arg types must be resolved before typing
-	for i, arg := range args {
+	for i, arg := range bodyArgs {
 		if IsFullyResolvedType(arg) {
 			continue
 		}
@@ -2516,6 +2532,7 @@ func (ts *TypeSolver) TypeScriptFunc(mangled string, template *ast.FuncStatement
 					panic(fmt.Sprintf("internal: cannot settle incomplete specialization %s", walked))
 				}
 			}
+			ts.settleEffects(ts.walkedFuncs)
 			for walked := range ts.walkedFuncs {
 				cached := ts.ScriptCompiler.Compiler.FuncCache[walked]
 				cached.Settled = true

--- a/compiler/solver.go
+++ b/compiler/solver.go
@@ -755,7 +755,7 @@ func (ts *TypeSolver) ensureScalarCallVariant(ce *ast.CallExpression) {
 	// Look up and create the scalar variant
 	template, mangled, ok := ts.lookupCallTemplate(ce, scalarArgs)
 	if ok {
-		ts.InferFuncTypes(ce, scalarArgs, scalarArgs, mangled, template)
+		ts.InferFuncTypes(ce, scalarArgs, mangled, template)
 	}
 }
 
@@ -2272,7 +2272,7 @@ func (ts *TypeSolver) TypeCallExpression(ce *ast.CallExpression, isRoot bool) []
 		return info.OutTypes
 	}
 
-	f := ts.InferFuncTypes(ce, innerArgs, args, mangled, template)
+	f := ts.InferFuncTypes(ce, innerArgs, mangled, template)
 	info.OutTypes = append([]Type(nil), f.Sig.OutTypes...)
 	info.ExprLen = len(info.OutTypes)
 	info.HasRanges = hasRanges
@@ -2447,7 +2447,7 @@ func (ts *TypeSolver) lookupCallTemplate(ce *ast.CallExpression, args []Type) (*
 // newFunc creates and caches a specialization record for the call.
 // String params keep their StrG/StrH type - functions are mangled separately for each.
 // Cache before inference so recursive calls can reuse the partial specialization.
-func (ts *TypeSolver) newFunc(ce *ast.CallExpression, bodyArgs, callArgs []Type, mangled string, template *ast.FuncStatement) *FuncInfo {
+func (ts *TypeSolver) newFunc(ce *ast.CallExpression, bodyArgs []Type, mangled string, template *ast.FuncStatement) *FuncInfo {
 	f := &FuncInfo{
 		Sig: Func{
 			Name:     ce.Function.Value,
@@ -2456,8 +2456,7 @@ func (ts *TypeSolver) newFunc(ce *ast.CallExpression, bodyArgs, callArgs []Type,
 		},
 		Vars:              make(map[string]Type),
 		StatementEffects:  make(map[*ast.LetStatement]StatementEffect),
-		OutputEffects:     slices.Repeat([]WriteEffect{WriteUncomputed}, len(template.Outputs)),
-		HasFunctionDomain: hasFunctionDomain(callArgs),
+		BodyOutputEffects: slices.Repeat([]WriteEffect{WriteUncomputed}, len(template.Outputs)),
 	}
 	for i := range f.Sig.OutTypes {
 		f.Sig.OutTypes[i] = Unresolved{}
@@ -2466,22 +2465,13 @@ func (ts *TypeSolver) newFunc(ce *ast.CallExpression, bodyArgs, callArgs []Type,
 	return f
 }
 
-func hasFunctionDomain(types []Type) bool {
-	for _, typ := range types {
-		if typ.Kind() == RangeKind || typ.Kind() == ArrayRangeKind {
-			return true
-		}
-	}
-	return false
-}
-
-func (ts *TypeSolver) InferFuncTypes(ce *ast.CallExpression, bodyArgs, callArgs []Type, mangled string, template *ast.FuncStatement) *FuncInfo {
+func (ts *TypeSolver) InferFuncTypes(ce *ast.CallExpression, bodyArgs []Type, mangled string, template *ast.FuncStatement) *FuncInfo {
 	// Fetch existing func cache entry (if any).
 	f, ok := ts.ScriptCompiler.Compiler.FuncCache[mangled]
 
 	// Create new Func if not cached (ok means recursive/previously seen call, reuse f)
 	if !ok {
-		f = ts.newFunc(ce, bodyArgs, callArgs, mangled, template)
+		f = ts.newFunc(ce, bodyArgs, mangled, template)
 	}
 
 	// Inside a function - unresolved args are allowed (resolved in later passes)

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -74,15 +74,15 @@ x, y`
 	args := []Type{I64}
 	template, isEvenMangled, ok := ts.lookupCallTemplate(call, args)
 	require.True(t, ok)
-	isEvenFunc := ts.newFunc(call, args, args, isEvenMangled, template)
-	require.Equal(t, []WriteEffect{WriteUncomputed, WriteUncomputed}, isEvenFunc.OutputEffects)
+	isEvenFunc := ts.newFunc(call, args, isEvenMangled, template)
+	require.Equal(t, []WriteEffect{WriteUncomputed, WriteUncomputed}, isEvenFunc.BodyOutputEffects)
 	isOddMangled := Mangle(cc.Compiler.MangledPath, "isOdd", args)
 
 	ts.Converging = false
 	ts.firstUnresolved = nil
 	clear(ts.walkedFuncs)
 	require.True(t, ts.TypeFunc(isEvenMangled, template))
-	require.Equal(t, []WriteEffect{WriteUncomputed, WriteUncomputed}, isEvenFunc.OutputEffects)
+	require.Equal(t, []WriteEffect{WriteUncomputed, WriteUncomputed}, isEvenFunc.BodyOutputEffects)
 	isOddFunc := cc.Compiler.FuncCache[isOddMangled]
 	require.NotNil(t, isOddFunc)
 	require.True(t, isEvenFunc.AllTypesInferred())
@@ -109,8 +109,8 @@ x, y`
 	require.False(t, ts.Converging)
 	require.True(t, isEvenFunc.Settled)
 	require.True(t, isOddFunc.Settled)
-	require.Equal(t, []WriteEffect{MayWrite, MayWrite}, isEvenFunc.OutputEffects)
-	require.Equal(t, []WriteEffect{MayWrite, MayWrite}, isOddFunc.OutputEffects)
+	require.Equal(t, []WriteEffect{MayWrite, MayWrite}, isEvenFunc.BodyOutputEffects)
+	require.Equal(t, []WriteEffect{MayWrite, MayWrite}, isOddFunc.BodyOutputEffects)
 
 	ts.Solve()
 	require.Empty(t, ts.Errors)

--- a/compiler/solver_test.go
+++ b/compiler/solver_test.go
@@ -74,13 +74,15 @@ x, y`
 	args := []Type{I64}
 	template, isEvenMangled, ok := ts.lookupCallTemplate(call, args)
 	require.True(t, ok)
-	isEvenFunc := ts.newFunc(call, args, isEvenMangled, template)
+	isEvenFunc := ts.newFunc(call, args, args, isEvenMangled, template)
+	require.Equal(t, []WriteEffect{WriteUncomputed, WriteUncomputed}, isEvenFunc.OutputEffects)
 	isOddMangled := Mangle(cc.Compiler.MangledPath, "isOdd", args)
 
 	ts.Converging = false
 	ts.firstUnresolved = nil
 	clear(ts.walkedFuncs)
 	require.True(t, ts.TypeFunc(isEvenMangled, template))
+	require.Equal(t, []WriteEffect{WriteUncomputed, WriteUncomputed}, isEvenFunc.OutputEffects)
 	isOddFunc := cc.Compiler.FuncCache[isOddMangled]
 	require.NotNil(t, isOddFunc)
 	require.True(t, isEvenFunc.AllTypesInferred())
@@ -107,6 +109,8 @@ x, y`
 	require.False(t, ts.Converging)
 	require.True(t, isEvenFunc.Settled)
 	require.True(t, isOddFunc.Settled)
+	require.Equal(t, []WriteEffect{MayWrite, MayWrite}, isEvenFunc.OutputEffects)
+	require.Equal(t, []WriteEffect{MayWrite, MayWrite}, isOddFunc.OutputEffects)
 
 	ts.Solve()
 	require.Empty(t, ts.Errors)

--- a/compiler/types.go
+++ b/compiler/types.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/thiremani/pluto/ast"
 	"github.com/thiremani/pluto/token"
 )
 
@@ -265,9 +266,12 @@ func (f Func) OutputTypesInferred() bool {
 
 // FuncInfo holds the mutable facts for one function specialization.
 type FuncInfo struct {
-	Sig     Func
-	Vars    map[string]Type
-	Settled bool
+	Sig               Func
+	Vars              map[string]Type
+	StatementEffects  map[*ast.LetStatement]StatementEffect
+	OutputEffects     []WriteEffect
+	HasFunctionDomain bool
+	Settled           bool
 }
 
 func (f *FuncInfo) AllTypesInferred() bool {

--- a/compiler/types.go
+++ b/compiler/types.go
@@ -266,11 +266,12 @@ func (f Func) OutputTypesInferred() bool {
 
 // FuncInfo holds the mutable facts for one function specialization.
 type FuncInfo struct {
-	Sig               Func
-	Vars              map[string]Type
-	StatementEffects  map[*ast.LetStatement]StatementEffect
-	OutputEffects     []WriteEffect
-	HasFunctionDomain bool
+	Sig              Func
+	Vars             map[string]Type
+	StatementEffects map[*ast.LetStatement]StatementEffect
+	// BodyOutputEffects summarizes the typed scalar body before a call-owned
+	// Range or ArrayRange domain determines whether that body executes.
+	BodyOutputEffects []WriteEffect
 	Settled           bool
 }
 

--- a/docs/Pluto IR Plan.md
+++ b/docs/Pluto IR Plan.md
@@ -724,26 +724,28 @@ instead of suppressing the invocation.
 
 ### Convergence and publication
 
-**Folding a body into an output summary.** A declared output's summary is the
-sequential fold of the body's per-slot effects for that output, in statement
-order: the output starts `MayWrite` (nothing has written it), a `MustWrite`
-statement slot sets it to `MustWrite`, and a `MayWrite` statement slot leaves
-it unchanged — a later conditional write cannot un-guarantee an earlier
-unconditional one. A function-owned domain then weakens the whole result:
-because a `Range` **or `ArrayRange`** parameter wraps the complete body and may
-execute zero times, every output the body writes only inside that domain
-becomes `MayWrite` at the function boundary. A range created *inside* the body
+**Folding a body into an output summary.** A declared output's body summary is
+the sequential fold of the body's per-slot effects for that output, in
+statement order: the output starts `MayWrite` (nothing has written it), a
+`MustWrite` statement slot sets it to `MustWrite`, and a `MayWrite` statement
+slot leaves it unchanged — a later conditional write cannot un-guarantee an
+earlier unconditional one. The published `BodyOutputEffects` deliberately stop
+before a call-owned domain: a `Range` or `ArrayRange` parameter controls whether
+the scalar body executes, not what the body does when it executes. Each call
+combines that reusable body summary with its solved domain. A provably
+non-empty literal can therefore preserve `MustWrite`, while an empty or unknown
+domain weakens the call to `MayWrite`. A range created *inside* the body still
 weakens only the outputs its statements drive — a possibly empty local range
 makes those slots `MayWrite`, so `UpperTriRowTail` publishes `MayWrite` for
-`res` — while unrelated outputs keep their effects. Only a parameter domain
-blanket-weakens the whole boundary.
+`res` — while unrelated outputs keep their effects.
 
-**Fixed point.** Function-output effects, and only those, need one: a recursive
-callee can refine its outputs after types settle, and `TypeScriptFunc` today
-converges on types alone. Condense the typed specialization call graph into its
-strongly connected components and process them **callee-first** in reverse
-topological order — this is what lets a component assume every callee outside
-it has already published. Within one component:
+**Fixed point.** Function-body output effects, and only those, need one: a
+recursive callee can refine its outputs after types settle, and
+`TypeScriptFunc` today converges on types alone. Condense the typed
+specialization call graph into its strongly connected components and process
+them **callee-first** in reverse topological order — this is what lets a
+component assume every callee outside it has already published. Within one
+component:
 
 1. Seed every member's outputs with a provisional `MustWrite` working vector. A
    recursive call reads that provisional value — which is why `Uncomputed`


### PR DESCRIPTION
## Summary

- add per-output `YieldEffect` and sparse per-target `WriteEffect` facts after type solving
- publish reusable scalar `BodyOutputEffects` and compose potentially empty function domains at each call site
- record semantic direct-return destination seed reads while keeping caller-side invocation failures separate
- settle recursive body summaries callee-first by SCC and validate facts before publication or consumption

## Why

The specialization-aware CFG and PIR builder need one solver-owned source of truth for whether expression outcomes yield and whether targets definitely receive values. Keeping body effects separate from call domains preserves `MustWrite` for a known non-empty range while still treating empty or unknown domains conservatively. This analysis-only step does not change CFG diagnostics or LLVM lowering.

## Validation

- `go test -race -count=1 ./lexer ./parser ./compiler`
- `go vet ./...`
- `python3 test.py` — 74 passed, 0 failed
- `git diff --check`
